### PR TITLE
Hook to add an optional custom middleware to express.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -237,6 +237,9 @@ exports.load = function loadSails (userConfig,cb) {
 				key: sessionKey
 			}));
 
+			if( typeof config.customMiddleware == 'function' )
+				config.customMiddleware();
+
 			// Set up router
 			app.use(app.router);
 		});


### PR DESCRIPTION
How's this look to you?  I added a check for a "customMiddleware" function in the config object, just before the router is added to express.  Then I could do this in my configuration:

```
'customMiddleware': function() {
    PassportService = require( './services/PassportAuthenticator' );
}
```

This makes my authentication service available as a global, and starts it early, while keeping it with the other services.  I changed its name so that it wouldn't get started twice.
