### PR TITLE
Configurable (optional) shutdown hook

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -334,6 +334,19 @@ exports.initialize = function initSails (userConfig){
 	else {
 		startServers();
 	}
+
+	if( _.isFunction( config.beforeShutdown )) 
+	{
+		process.on('SIGINT', function() {
+			process.exit();
+		});
+		process.on( 'SIGTERM', function() {
+			process.exit();
+		} );
+		process.on( 'exit', function() {
+			config.beforeShutdown();
+		} );
+	}
 	
 	// start the ws(s):// and http(s):// servers
 	function startServers (){


### PR DESCRIPTION
This checks for a function beforeShutdown() in the config object, and ties it in to the process shutdown process if it exists.
