### PR TITLE
Added an option to provide express server options in config.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -240,7 +240,10 @@ exports.load = function loadSails (userConfig,cb) {
 
 		// HTTP
 		//var app = module.exports = express.createServer();
-		app = express.createServer();
+		if( _.isUndefined( config.serverOptions ))
+			app = express.createServer();
+		else
+			app = express.createServer( config.serverOptions );
 
 		// Configuration
 		// Enable JSONP


### PR DESCRIPTION
I added optional arguments to express.createServer(), which makes it very simple to run an HTTPS server just by specifying the cert locations in my config. 
