### PR TITLE
Fix for converting strings to integers

### DIFF
--- a/lib/waterline/normalize.js
+++ b/lib/waterline/normalize.js
@@ -150,7 +150,7 @@ function numberizeModel (model) {
 
 // If specified attr looks like a number, but it's a string, cast it to a number
 function numberize (attr) {
-	if (_.isString(attr) && isNumbery(attr)) return +attr; 
+	if (_.isString(attr) && isNumbery(attr) && parseInt(attr,10) < Math.pow(2, 53)) return +attr; 
 	else return attr;
 }
 


### PR DESCRIPTION
Convert only numbers lower then 2^53
