### PR TITLE
Added attribute scaffolding for models

### DIFF
--- a/bin/blueprints/attribute.js
+++ b/bin/blueprints/attribute.js
@@ -1,0 +1,4 @@
+
+		<%- attribute.name %>: {
+			type: '<%- attribute.type %>'
+		}

--- a/bin/blueprints/model.js
+++ b/bin/blueprints/model.js
@@ -1,9 +1,9 @@
 /*---------------------
-	:: <%- entity %> 
+	:: <%- entity %>
 	-> model
 ---------------------*/
 module.exports = {
-	
+
 	attributes	: {
 
 		// Simple attribute:
@@ -14,6 +14,7 @@ module.exports = {
 		//	type: 'STRING',
 		//	defaultValue: '555-555-5555'
 		// }
+		<%- attributes %>
 	}
 
 };


### PR DESCRIPTION
For use as:
sails generate model User name:string birthday:date age:integer

I didn't account for mapping shorthand (like "int" or "str") to full versions.

This generates the nested model structure (instead of just using the type as a string) as that seems more forward-compatible (with defaultValue, etc).

Let me know if there are any problems or if I also need to update tests or adjust anything for conventions or completeness.
