### PR TITLE
routing based on controller.action syntax

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -102,14 +102,24 @@ function fetchRoute(url, verb) {
 	}
 	// Target is a string which maps to a controller/action which may not exist yet
 	else if(_.isString(target)) {
-		// Parse the entity/action for this url
-		var routeObj = sails.util.parsePath(target);
+		
+		// If route has a '/' parse as path else parse as controller.route		
+		if(target.match('/')) {
+			// Parse the entity/action for this url
+			var routeObj = sails.util.parsePath(target);
 
-		// Add controller key to route object to map to routes.js conventions
-		routeObj.controller = routeObj.entity;
+			// Add controller key to route object to map to routes.js conventions
+			routeObj.controller = routeObj.entity;
 
-		// Return a complete route object for this target URL
-		return _.extend(routeObj, {verb: verb});
+			// Return a complete route object for this target URL
+			return _.extend(routeObj, {verb: verb});	
+		} else {
+			//Parse the target into controller/route when controller.route syntax is used			
+			var routeObj = sails.util.parseStringRoute(target)
+
+			//Return the route object
+			return _.extend(routeObj, { verb: verb });
+		}
 	}
 	// No match exists, return null
 	else if (!target) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -20,6 +20,25 @@ exports.parsePath = function(path) {
 	return parsedPath;
 };
 
+/**
+ * Parse a string to determine a controller/action based on 
+ * controller.action syntax  
+ */
+exports.parseStringRoute = function(routeStr) {
+	// Split the url and find controller/action
+	var entities = routeStr.split('.');
+	
+	
+	var routeObj = {
+		controller: entities[0]
+	}
+	// If action exists put it inside the routeObj
+	if(entities[1]) {
+		routeObj = _.extend(routeObj, { action: entities[1] });
+	}
+
+	return routeObj;
+}
 
 /**
  * Run a method meant for a single object on a object OR array


### PR DESCRIPTION
Added the routing for controller.action syntax. User can still use the old syntax of creating object literals for routes.

'/' : {
    controller: 'home',
    action: 'index'
}

or

'/' : 'home.index'
