### PR TITLE
Adding options to .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,7 @@
 {
+  "bitwise": true,
+  "camelcase": true,
+  "node": true,
   "undef": true,
   "unused": true,
   "curly": true,
@@ -7,7 +10,7 @@
   "noarg": true,
   "noempty": true,
   "plusplus": true,
-  "quotmark": true,
+  "quotmark": "single",
   "trailing": true,
   "asi": false,
   "eqnull": true,


### PR DESCRIPTION
I added the following options to the .jshintrc file and have included their description from the jshint documentation:
#### bitwise:

 This option prohibits the use of bitwise operators such as ^ (XOR), | (OR) and others. Bitwise operators are very rare in JavaScript programs and quite often & is simply a mistyped &&.
#### camelcase:

This option allows you to force all variable names to use either camelCase style or UPPER_CASE with underscores.
#### node:

This option defines globals available when your code is running inside of the Node runtime environment.

And I changed quotmark to be more specific so it outputs better errors.
