### PR TITLE
Improved CoffeeScipt error reporting

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -23,35 +23,44 @@ var JavascriptAsset = rack.Asset.extend({
 		self.paths = search(sails.config.assets.sequence, /(\.js|\.coffee|\.ts)$/);
 		self.assets = [];
 		async.forEachSeries(self.paths, function(path, next) {
-			var asset;
+			var assetContent = fs.readFileSync(path, 'utf8');
+			var finalContent = '';
+			var assetUrl;
 			if (path.indexOf('.coffee') !== -1) {
+				assetUrl = '/' + pathutil.relative(sails.config.appPath, path).replace('.coffee', '.js').replace(/\\/g, '/');
 				var coffee = require('coffee-script');
-				asset = new rack.Asset({
-					mimetype: 'text/javascript',
-					url: '/' + pathutil.relative(sails.config.appPath, path).replace('.coffee', '.js').replace(/\\/g, '/'),
-					contents: coffee.compile(fs.readFileSync(path, 'utf8'))
-				});
-			} else if (path.indexOf('.ts') !== -1) {
-				var tsc = require('node-typescript');
-				var jscode = null;
 				try {
-					jscode = tsc.compile(path, fs.readFileSync(path, 'utf8'));
+					finalContent = coffee.compile(assetContent);
 				} catch (e) {
-					jscode = '';
+					sails.log.error('CoffeeScript compilation failed:');
+					// Log CoffeeScript compilation error
+					sails.log.error(e);
+					// Include filepath from project root
+					sails.log.error('In file: ' + path.replace(sails.config.appPath, ''));
+					// Include line number of error
+					sails.log.error('On line: ' + (e.location.first_line - 1));
+					// Include problematic line and indicate offending character
+					sails.log.error( _.str.lines(assetContent)[e.location.first_line]);
+					sails.log.error( '\x1B[31m' + _.str.pad('^', e.location.first_column + 1) + '\x1B[39m');
 				}
-				asset = new rack.Asset({
-					mimetype: 'text/javascript',
-					url: '/' + pathutil.relative(sails.config.appPath, path).replace('.ts', '.js').replace(/\\/g, '/'),
-					contents: jscode
-				});
+			} else if (path.indexOf('.ts') !== -1) {
+				assetUrl = '/' + pathutil.relative(sails.config.appPath, path).replace('.ts', '.js').replace(/\\/g, '/');
+				var tsc = require('node-typescript');
+				try {
+					finalContent = tsc.compile(path, assetContent);
+				} catch (e) {
+					sails.log.error('TypeScript compilation failed:');
+					sails.log.error(e);
+				}
 			} else {
-				asset = new rack.Asset({
-					mimetype: 'text/javascript',
-					url: '/' + pathutil.relative(sails.config.appPath, path).replace(/\\/g, '/'),
-					contents: fs.readFileSync(path, 'utf8')
-				});
+				assetUrl = '/' + pathutil.relative(sails.config.appPath, path).replace(/\\/g, '/');
 			}
-			asset.isDev = true;
+			var asset = new rack.Asset({
+				mimetype: 'text/javascript',
+				url: assetUrl,
+				contents: finalContent,
+				isDev : true
+			});
 			self.assets.push(asset);
 			asset.on('complete', next);
 		}, function(error) {


### PR DESCRIPTION
When there is a compilation error, it now throws this and restarts the server:

```
error: CoffeeScript compilation failed:
error: SyntaxError: unexpected )
error: In file: /assets/js/views/app.coffee
error: On line: 13
error:   initialize: () -
error:                ^
```

The current behavior after a compilation error is to keep restarting the server (if your using forever) and displaying this error.

```
/Users/colinwren/Projects/testProject/node_modules/sails/node_modules/coffee-script/lib/coffee-script/helpers.js:211
    throw error;
          ^
SyntaxError: unexpected )
    at Object.exports.throwSyntaxError (/Users/colinwren/Projects/testProject/node_modules/sails/node_modules/coffee-script/lib/coffee-script/helpers.js:209:13)
    at Object.parser.yy.parseError (/Users/colinwren/Projects/testProject/node_modules/sails/node_modules/coffee-script/lib/coffee-script/coffee-script.js:245:20)
    at Object.parse (/Users/colinwren/Projects/testProject/node_modules/sails/node_modules/coffee-script/lib/coffee-script/parser.js:535:22)
    at Object.exports.compile.compile (/Users/colinwren/Projects/testProject/node_modules/sails/node_modules/coffee-script/lib/coffee-script/coffee-script.js:36:25)
    at async.forEachSeries.self.contents (/Users/colinwren/Projects/testProject/node_modules/sails/lib/assets.js:32:23)
    at iterate (/Users/colinwren/Projects/testProject/node_modules/sails/node_modules/async/lib/async.js:108:13)
    at Asset.<anonymous> (/Users/colinwren/Projects/testProject/node_modules/sails/node_modules/async/lib/async.js:119:25)
    at Asset.EventEmitter.emit (events.js:92:17)
    at Asset.<anonymous> (/Users/colinwren/Projects/testProject/node_modules/sails/node_modules/asset-rack/compiled/asset.js:89:22)
    at Asset.EventEmitter.emit (events.js:92:17)
    at Asset.exports.Asset.Asset.create (/Users/colinwren/Projects/testProject/node_modules/sails/node_modules/asset-rack/compiled/asset.js:180:19)
    at /Users/colinwren/Projects/testProject/node_modules/sails/node_modules/asset-rack/compiled/asset.js:117:24
    at process._tickCallback (node.js:415:13)
```
