### PR TITLE
Bump include-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "asset-rack": "2.1.5",
     "node-uuid": "~1.4.0",
     "parley": "0.0.2",
-    "include-all": "0.0.5",
+    "include-all": "0.0.6",
     "forever": "~0.10.0",
     "clean-css": "0.10.1",
     "fs-watch-tree": "~0.2.2",


### PR DESCRIPTION
Whoops so in order for the global underscore to work when it's turned off we need to bump versions on the `include-all` dependency once pushed to npm.

You get the nasty `_` is not defined when the global is turned off from the include-all dep.
