### PR TITLE
update index page for jade boilerplate

### DIFF
--- a/bin/boilerplates/jade/index.jade
+++ b/bin/boilerplates/jade/index.jade
@@ -1,19 +1,22 @@
 extends ../layout
 
 block body
-  h1.header
-    a(href='/') Hello world
+  h1#header
+    a(href='/') New Sails App
   #content
     h2 It works!
     p You've successfully installed the Sails Framework.
-    p Sails is a modern, realtime MVC framework for the Node.js platform.  It helps you build apps fast.
+    p
+      |Sails is a modern, realtime MVC framework for the Node.js platform.
+      br
+      span.highlight It helps you build apps fast.
     p
       a.button(href="https://github.com/balderdashy/sails/wiki")
         span Documentation
       a.button(href="https://github.com/balderdashy/sails/wiki/Changelog")
         span Changelog
 
-  .footer
+  #footer
     a.copyright(href="http://sailsjs.com") built with Sails.js
 
   style


### PR DESCRIPTION
Minor changes to the jade boilerplate to ensure a new sails app created with 'sails new project --template=jade' produces the same html as a new sails app using the default ejs templates. 
