### PR TITLE
Model.findOrCreate() Bug

### DIFF
--- a/lib/waterline/adapter/aggregateQueries.js
+++ b/lib/waterline/adapter/aggregateQueries.js
@@ -28,7 +28,7 @@ module.exports = function(adapterDef) {
 		},
 
 		// If an optimized findOrCreateEach exists, use it, otherwise use an asynchronous loop with create()
-		findOrCreateEach: function (collectionName, attributesToCheck, valuesList, cb) {
+		findOrCreateEach: function (collection, collectionName, attributesToCheck, valuesList, cb) {
 			var self = this;
 
 			// Clone sensitive data
@@ -56,7 +56,7 @@ module.exports = function(adapterDef) {
 						criteria[attrName] = values[attrName];
 					});
 
-					return self.findOrCreate(collectionName, criteria, values, function (err, model) {
+					return self.findOrCreate(collection, collectionName, criteria, values, function (err, model) {
 						// Add model to list
 						if (model) models.push(model);
 						return cb(err, model);

--- a/lib/waterline/adapter/compoundQueries.js
+++ b/lib/waterline/adapter/compoundQueries.js
@@ -8,8 +8,8 @@ var normalize = require('../normalize.js');
 module.exports = function(adapterDef) {
 
 	var pub = {
-		
-		findOrCreate: function(collectionName, criteria, values, cb) {
+
+		findOrCreate: function(collection, collectionName, criteria, values, cb) {
 			var self = this;
 
 			// If no values were specified, use criteria
@@ -24,9 +24,12 @@ module.exports = function(adapterDef) {
 			// WARNING: Not transactional!  (unless your data adapter is)
 			else {
 				self.find(collectionName, criteria, function(err, result) {
-					if(err) cb(err);
-					else if(result) cb(null, result);
-					else self.create(collectionName, values, cb);
+					if(err) return cb(err);
+					if(result) return cb(null, result);
+
+					// Call Collection's .create()
+					// This gives us the default values and timestamps
+					return collection.create(values, cb);
 				});
 			}
 

--- a/lib/waterline/collection.js
+++ b/lib/waterline/collection.js
@@ -520,7 +520,7 @@ function Collection (definition, adapter, cb) {
 		if(!_.isFunction(cb)) return usageError('Invalid callback specified!', usage, cb);
 
 		// Build model(s) from result set
-		return adapter.findOrCreate(this.identity, criteria, values, buildModel(this, cb));
+		return adapter.findOrCreate(this, this.identity, criteria, values, buildModel(this, cb));
 	};
 
 
@@ -571,7 +571,7 @@ function Collection (definition, adapter, cb) {
 		})) return usageError('Invalid valuesList specified (should be an array of valid values objects!)', usage, cb);
 
 		// Build model(s) from result set
-		adapter.findOrCreateEach(this.identity, attributesToCheck, valuesList, buildModel(this, cb));
+		adapter.findOrCreateEach(this, this.identity, attributesToCheck, valuesList, buildModel(this, cb));
 	};
 
 	//////////////////////////////////////////

--- a/test/waterline/adapter/aggregateQueries.test.js
+++ b/test/waterline/adapter/aggregateQueries.test.js
@@ -15,9 +15,9 @@ var async = require('async');
 var parley = require('parley');
 var assert = require("assert");
 
-describe('findOrCreate()', function() {
+describe('findOrCreateEach()', function() {
 
-	var testName = 'findOrCreate([])';
+	var testName = 'findOrCreateEach([])';
 	var testData = [{
 		name: 'marge',
 		type: testName

--- a/test/waterline/adapter/compoundQueries.test.js
+++ b/test/waterline/adapter/compoundQueries.test.js
@@ -1,0 +1,80 @@
+/**
+ * compoundQueries.test.js
+ *
+ * This module tests compound operations:
+ * findOrCreate()
+ *
+ */
+
+// Dependencies
+var assert = require('assert');
+
+
+describe('findOrCreate()', function() {
+
+  describe('database records', function() {
+
+    // Create a base user
+    before(function(done) {
+      User.create({ name: 'findOrCreate()' }, function(err, res) {
+        done();
+      });
+    });
+
+    // Test that the user is found
+    it('should find the user', function(done) {
+      User.findOrCreate({ name: 'findOrCreate()' }, { name: 'findOrCreate()' }, function(err, res) {
+        if(err) return done(new Error(err));
+        assert.equal('findOrCreate()', res.name, 'A different record was returned');
+
+        User.findAll({ name: 'findOrCreate()' }, function(err, res) {
+          assert.equal(1, res.length, 'More than 1 user returned');
+          done();
+        });
+
+      });
+    });
+
+    // Test that a new user is created
+    it('should find the user', function(done) {
+      User.findOrCreate({ name: 'new findOrCreate()' }, { name: 'new findOrCreate()' }, function(err, res) {
+        if(err) return done(new Error(err));
+        assert.equal('new findOrCreate()', res.name, 'A different record was returned');
+
+        User.findAll({ name: 'new findOrCreate()' }, function(err, res) {
+          assert.equal(1, res.length, 'More than 1 user returned');
+          done();
+        });
+
+      });
+    });
+
+  });
+
+
+  it('should add timestamp properties', function(done) {
+
+    User.findOrCreate({ name: 'timestamp test' }, { name: 'timestamp test' }, function(err, res) {
+      if(err) return done(new Error(err));
+      if(!res) return done(new Error('No result was returned'));
+
+      if(res.createdAt === null) return done(new Error('Did not properly add timestamps'));
+      if(res.updatedAt === null) return done(new Error('Did not properly add timestamps'));
+      done();
+    });
+
+  });
+
+  it('should add default values', function(done) {
+
+    User.findOrCreate({ name: 'defaults test' }, { name: 'defaults test' }, function(err, res) {
+      if(err) return done(new Error(err));
+      if(!res) return done(new Error('No result was returned'));
+
+      assert.equal(res.favoriteFruit, 'blueberry', 'Default values not being set');
+      done();
+    });
+
+  });
+
+});


### PR DESCRIPTION
This fixes an issue I came across where .findOrCreate on a collection doesn't add in timestamp values or default values when creating a record.

The timestamps and defaults are set in the `collection.create()` method but the aggregate and compound methods don't use the collection create method and instead just pass it off to the adapter's create method.

I changed it so that they both use the collection's create method and get the values set. I wrote a test suite for the compoundQueries to ensure it's all good.
