### PR TITLE
Prevented default session.adapter from overwriting custom session.store

### DIFF
--- a/lib/configuration/build.js
+++ b/lib/configuration/build.js
@@ -15,7 +15,7 @@ module.exports = function (defaults,userConfig) {
 	// Then extend each of the config subobjects
 	result.assets	= _.extend(defaults.assets,userConfig.assets || {});
 	result.session	= _.extend(defaults.session,userConfig.session || {});
-    if (result.session.adapter === 'memory') {
+    if (result.session.adapter === 'memory' && !_.isObject(result.session.store)) {
         result.session.store = new (require('express').session.MemoryStore)();
     }
     if (result.session.adapter === 'redis') {


### PR DESCRIPTION
In the configuration, failure to set session.adapter overwrites session.store, even when a custom store like redis is used.
