### PR TITLE
Added missing CSS compile code

### DIFF
--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -106,6 +106,13 @@ var CssAsset = rack.Asset.extend({
 			asset.on('complete', next);
 		}, function(error) {
 			if (error) self.emit('error', error);
+			self.contents = '';
+			if (isProduction) {
+				_.each(self.assets, function(asset) {
+					self.contents += asset.contents + '\n';
+				});
+				self.contents = cleancss.process(self.contents);
+			}
 			self.isDev = false;
 			self.emit('created');
 		});


### PR DESCRIPTION
In production mode the CSS assets were not compiling. It looks like a snippet was left out after a refactoring. As a result /style.css was not generated in production mode.
