### PR TITLE
Added support for environment specific static asset directories

### DIFF
--- a/lib/configuration/express.js
+++ b/lib/configuration/express.js
@@ -100,11 +100,15 @@ exports.configure = function configure(cb) {
 
 			// Allow access to static dirs
 
-			// In production mode, 
+			// In production mode,
 			// configure access to public dir w/ a cache maxAge
 			if (sails.config.environment === 'production') {
 
-				sails.express.app.use(express['static'](sails.config.paths['public'], {
+				// If a production public directory is configured, use it,
+				// otherwise fall back to public
+				var productionPublicDir = sails.config.paths.productionPublic || sails.config.paths['public'];
+
+				sails.express.app.use(express['static'](productionPublicDir, {
 					maxAge: sails.config.cache.maxAge
 				}));
 			}


### PR DESCRIPTION
This allows for configuration of the folder that express serves static files from with `productionPublic` 
