### PR TITLE
Fixes #310 error with defaultsTo not being set correctly

### DIFF
--- a/lib/waterline/collection.js
+++ b/lib/waterline/collection.js
@@ -246,10 +246,14 @@ function Collection (definition, adapter, cb) {
 
 		// Populate default values
 		_.each(this.attributes, function (scheme, attrName) {
-			if (_.isObject(scheme) && scheme.defaultsTo) {
+			// Ignore if value is set
+			if(values[attrName]) return;
+
+			// Set default value if available
+			if (_.isObject(scheme) && typeof scheme.defaultsTo !== 'undefined') {
 				values[attrName] = scheme.defaultsTo;
 			}
-		}, this);
+		});
 
 		// TODO: Validate constraints using Anchor
 

--- a/test/waterline/defaultsTo.test.js
+++ b/test/waterline/defaultsTo.test.js
@@ -1,25 +1,49 @@
 /**
  * defaultsTo.test.js
- *
- *
  */
+
 // Dependencies
 var _ = require('underscore');
 var parley = require('parley');
 var assert = require("assert");
 
-
 describe('defaultsTo', function() {
 
-	it('should automatically set default values for unspecified attributes in create', function(cb) {
-		User.create({
-			name: "Johnny"
-		}, function (err, user) {
-			if (err) return cb(new Error(err));
-			if (!user) return cb(new Error("No user returned by create()."));
-			if (user.favoriteFruit !== 'blueberry') return cb(new Error("Favorite fruit default not properly applied!"));
-			return cb();
-		});
-	});
+  it('should automatically set default value', function(done) {
+    User.create({ name: "Johnny" }, function(err, user) {
+      if (err) return done(new Error(err));
+      if (!user) return done(new Error("No user returned by create()."));
 
+      assert.equal(user.favoriteFruit, 'blueberry');
+      done();
+    });
+  });
+
+  describe('with boolean type', function() {
+
+    it('should automatically set default value', function(done) {
+      User.create({}, function(err, user) {
+        if (err) return done(new Error(err));
+        if (!user) return done(new Error("No user returned by create()."));
+
+        assert.equal(user.status, 0);
+        done();
+      });
+    });
+
+  });
+
+  describe('with override', function() {
+
+    it('should automatically set default value', function(done) {
+      User.create({ favoriteFruit: 'strawberry' }, function(err, user) {
+        if (err) return done(new Error(err));
+        if (!user) return done(new Error("No user returned by create()."));
+
+        assert.equal(user.favoriteFruit, 'strawberry');
+        done();
+      });
+    });
+
+  });
 });

--- a/test/waterline/fixtures/collections/User.js
+++ b/test/waterline/fixtures/collections/User.js
@@ -53,7 +53,11 @@ exports.attributes = {
 		defaultsTo: 'blueberry',
 		type: 'string'
 	},
-	age		: 'integer'
+	age		: 'integer',
+	status: {
+		type: 'boolean',
+		defaultsTo: 0
+	}
 };
 
 // Identity is here to facilitate unit testing


### PR DESCRIPTION
This should fix #310 I believe. I ran into the issue where a boolean value of 0 for the defaultsTo was not being set correctly.

The problem is that the line `if (_.isObject(scheme) && scheme.defaultsTo)` requires the defaultsTo value to evaluate to true. In reality it evaluates to either undefined or the default value.

It should also fix the issue where the defaultsTo value was being set even if a value was passed in.

I added some more tests to the `defaultsTo.test.js` file as well to test everything is working as expected.
