### PR TITLE
Add support for configuration of multiple static file directories

### DIFF
--- a/lib/configuration/express.js
+++ b/lib/configuration/express.js
@@ -98,26 +98,26 @@ exports.configure = function configure(cb) {
 
 		function afterwards(err) {
 
-			// Allow access to static dirs
+			// Static middleware configuration
+			var staticDirs = sails.config.paths['public'];
+			var staticOptions = {};
 
-			// In production mode,
-			// configure access to public dir w/ a cache maxAge
 			if (sails.config.environment === 'production') {
 
 				// If a production public directory is configured, use it,
 				// otherwise fall back to public
-				var productionPublicDir = sails.config.paths.productionPublic || sails.config.paths['public'];
+				staticDirs = sails.config.paths.productionPublic || staticDirs;
 
-				sails.express.app.use(express['static'](productionPublicDir, {
-					maxAge: sails.config.cache.maxAge
-				}));
+				// configure a cache maxAge
+				staticOptions.maxAge = sails.config.cache.maxAge;
 			}
 
-			// In development mode, don't cache.
-			else {
-				sails.express.app.use(express['static'](sails.config.paths['public']));
-			}
+			// If staticDirs is string, make it into an array
+			if (_.isString(staticDirs)) staticDirs = [staticDirs];
 
+			_.each(staticDirs, function(dirName) {
+				sails.express.app.use(express['static'](dirName, staticOptions));
+			});
 
 			// Use the specified cookieParser
 			if (sails.config.express.cookieParser) {
@@ -129,7 +129,7 @@ exports.configure = function configure(cb) {
 
 			// Add annoying Sails header instead of annoying Express header
 			sails.express.app.use(function(req, res, next) {
-				res.header("X-Powered-By", 'Sails <sailsjs.org>)');
+				res.header('X-Powered-By', 'Sails <sailsjs.org>)');
 				next();
 			});
 


### PR DESCRIPTION
This allows for users to specify multiple directories to server static files from.

`public` and `productionPublic` can be given a string for a single directory or an array for multiple directories like so:

``` javascript
paths: {
  public: ['.tmp', 'public'],
  productionPublic: 'dist'
}
```
