### PR TITLE
Added support for .styl stylus assets

### DIFF
--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -106,6 +106,13 @@ var CssAsset = rack.Asset.extend({
 			asset.isDev = true;
 			self.assets.push(asset);
 			asset.on('complete', next);
+			asset.on('error', function(e) {
+				if (type !== undefined)
+					sails.log.error(type+' compilation failed:');
+				sails.log.error(e);
+				next();
+			});
+
 		}, function(error) {
 			if (error) self.emit('error', error);
 			self.contents = '';


### PR DESCRIPTION
This pull request adds stylus support to sails and introduces a minor refactoring of the css assets code which should make it easier to add other css languages (although they are still hardcoded into assets/index.js.. that should probably change at some point).

I realize there is a discussion going on in https://github.com/balderdashy/sails/issues/240 about how best to integrate with yeoman. As a sails newb I did not want to complicate things by trying to learn two frameworks at once (and yeoman does not generate simple code) so I built this to keep things simple and sails-centric.

Cheers,
Rob
