### PR TITLE
Asserting only a minimum version of asset-rack so it can be overriden

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "i18n": "0.3.5",
     "wrench": "1.4.4",
     "uglify-js": "2.2.4",
-    "asset-rack": "2.1.5",
+    "asset-rack": ">=2.1.5",
     "node-uuid": "~1.4.0",
     "parley": "0.0.2",
     "include-all": "0.0.6",


### PR DESCRIPTION
Sails' dependence on a specific version of asset-rack was preventing me from using my own fork of asset-rack so I switched it to >=.

We might want to do the same thing for sail's other dependencies, it seems like a best practice IMHO to allow dev's to easily hack away.

Cheers,
Rob
