### PR TITLE
Make existsSync work with older versions of Node

### DIFF
--- a/bin/sails.js
+++ b/bin/sails.js
@@ -9,8 +9,7 @@ var util = require('util');
 var forever = require('forever');
 
 // Make existsSync not crash on older versions of Node
-var existsSync = fs.existsSync || require('path').existsSync;
-fs.existsSync = existsSync;
+fs.existsSync = fs.existsSync || require('path').existsSync;
 
 var argv = require('optimist').argv;
 require('coffee-script');

--- a/lib/configuration/validate.js
+++ b/lib/configuration/validate.js
@@ -2,8 +2,7 @@ var _ = require('underscore');
 
 // Make existsSync not crash on older versions of Node
 var fs = require('fs');
-var existsSync = fs.existsSync || require('path').existsSync;
-fs.existsSync = existsSync;
+fs.existsSync = fs.existsSync || require('path').existsSync;
 
 
 // Normalize legacy and duplicative user config settings

--- a/lib/waterline/index.js
+++ b/lib/waterline/index.js
@@ -14,8 +14,7 @@ var util = require('../util');
 var fs = require('fs-extra');
 
 // Make existsSync not crash on older versions of Node
-var existsSync = fs.existsSync || require('path').existsSync;
-fs.existsSync = existsSync;
+fs.existsSync = fs.existsSync || require('path').existsSync;
 
 
 /**

--- a/test/cli/generate.test.js
+++ b/test/cli/generate.test.js
@@ -4,8 +4,7 @@ var wrench = require('wrench');
 var exec = require('child_process').exec;
 
 // Make existsSync not crash on older versions of Node
-var existsSync = fs.existsSync || require('path').existsSync;
-fs.existsSync = existsSync;
+fs.existsSync = fs.existsSync || require('path').existsSync;
 
 function capitalize(string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);

--- a/test/cli/lift.test.js
+++ b/test/cli/lift.test.js
@@ -6,8 +6,7 @@ var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
 
 // Make existsSync not crash on older versions of Node
-var existsSync = fs.existsSync || require('path').existsSync;
-fs.existsSync = existsSync;
+fs.existsSync = fs.existsSync || require('path').existsSync;
 
 describe('Starting sails server with lift', function() {
 	var sailsBin = './bin/sails.js';

--- a/test/http/helpers/appHelper.js
+++ b/test/http/helpers/appHelper.js
@@ -5,8 +5,7 @@ var path = require('path');
 var sailsBin = path.resolve('./bin/sails.js');
 
 // Make existsSync not crash on older versions of Node
-var existsSync = fs.existsSync || path.existsSync;
-fs.existsSync = existsSync;
+fs.existsSync = fs.existsSync || path.existsSync;
 
 /**
  * Uses the Sails binary to create a namespaced test app


### PR DESCRIPTION
On older versions of Node, attempts to use fs.existsSync results in a crash with error:
`TypeError: Object #<Object> has no method 'existsSync'`

Unfortunately at this time, the [maximum version of Node available on appFog](https://docs.appfog.com/languages/node) is 0.8.14, which exhibits this error.

This change is a workaround for that issue.  It does a basic null check for fs.existsSync.  If it doesn't exist, it requires the 'path' module and uses path.existsSync instead.  If fs.existsSync exists, then the 'path' module won't be imported unnecessarily. 
