### PR TITLE
Adjusted the "to see your app, visit:" log message on startup ...

### DIFF
--- a/lib/sails.js
+++ b/lib/sails.js
@@ -379,10 +379,8 @@ function initSails(cb) {
 			sails.log('Sails lifted on port ' + sails.config.port + ' in ' + sails.config.environment + ' mode.');
 			
 			if (sails.config.environment === 'development') {
-				var usingSSL = false;
-				if( ( sails.config.serverOptions && sails.config.serverOptions.key && sails.config.serverOptions.cert ) ||
-					( sails.config.express && sails.config.express.serverOptions && sails.config.express.serverOptions.key && sails.config.express.serverOptions.cert ))
-					usingSSL = true;
+				var usingSSL = ( ( sails.config.serverOptions && sails.config.serverOptions.key && sails.config.serverOptions.cert ) ||
+					( sails.config.express && sails.config.express.serverOptions && sails.config.express.serverOptions.key && sails.config.express.serverOptions.cert ));
 
 				sails.log();
 				sails.log('( to see your app, visit: ' + ( usingSSL ? 'https' : 'http' ) + '://' + sails.config.host + ':' + sails.config.port + ' )');


### PR DESCRIPTION
to show "https:" instead of "http:" if there's a key and certificate specified.

I know it's not a big deal, but I hate being lied to by debug messages!
