### PR TITLE
 Adding Snockets compilation of js, cs and ts files

### DIFF
--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -23,47 +23,38 @@ var JavascriptAsset = rack.Asset.extend({
 		self.paths = search(sails.config.assets.sequence, /(\.js|\.coffee|\.ts)$/);
 		self.assets = [];
 		async.forEachSeries(self.paths, function(path, next) {
-			var assetContent = fs.readFileSync(path, 'utf8');
-			var finalContent = '';
-			var assetUrl;
-			if (path.indexOf('.coffee') !== -1) {
-				assetUrl = '/' + pathutil.relative(sails.config.appPath, path).replace('.coffee', '.js').replace(/\\/g, '/');
-				var coffee = require('coffee-script');
-				try {
-					finalContent = coffee.compile(assetContent);
-				} catch (e) {
-					sails.log.error('CoffeeScript compilation failed:');
-					// Log CoffeeScript compilation error
-					sails.log.error(e);
-					// Include filepath from project root
-					sails.log.error('In file: ' + path.replace(sails.config.appPath, ''));
-					// Include line number of error
-					sails.log.error('On line: ' + (e.location.first_line - 1));
-					// Include problematic line and indicate offending character
-					sails.log.error( _.str.lines(assetContent)[e.location.first_line]);
-					sails.log.error( '\x1B[31m' + _.str.pad('^', e.location.first_column + 1) + '\x1B[39m');
-				}
-			} else if (path.indexOf('.ts') !== -1) {
-				assetUrl = '/' + pathutil.relative(sails.config.appPath, path).replace('.ts', '.js').replace(/\\/g, '/');
+			var ext = pathutil.extname(path);
+			var extensionHandlers = [];
+
+			var assetUrl = '/' + pathutil.relative(sails.config.appPath, path)
+				.replace(ext, '.js')
+				.replace(/\\/g, '/');
+
+			if (path.indexOf('.ts') !== -1) {
 				var tsc = require('node-typescript');
-				try {
-					finalContent = tsc.compile(path, assetContent);
-				} catch (e) {
-					sails.log.error('TypeScript compilation failed:');
-					sails.log.error(e);
-				}
-			} else {
-				assetUrl = '/' + pathutil.relative(sails.config.appPath, path).replace(/\\/g, '/');
-				finalContent = assetContent;
+				extensionHandlers.push [{ ext: 'ts', handler: tsc.compile }]
 			}
-			var asset = new rack.Asset({
-				mimetype: 'text/javascript',
-				url: assetUrl,
-				contents: finalContent
-			});
+
+      var asset = new rack.SnocketsAsset({
+        mimetype: 'text/javascript',
+        filename: path,
+        url: assetUrl,
+        compress: false
+      });
+
 			asset.isDev = true;
 			self.assets.push(asset);
 			asset.on('complete', next);
+			asset.on('error', function(e) {
+				if(ext == ".coffee") {
+					sails.log.error('CoffeeScript compilation failed:');
+				}
+				else if(ext == ".ts") {
+					sails.log.error('TypeScript compilation failed:');
+				}
+				sails.log.error(e);
+			});
+
 		}, function(error) {
 			if (error) self.emit('error', error);
 			self.contents = '';


### PR DESCRIPTION
This patch adds snockets support to sails via asset-rack. The major issue this addresses is dependency management in client side code.

From my perspective `#= require "my_dependency"` has always been very readable, predictable and concise.

But I wonder if there are different camps on this. What's the consensus?

originally https://github.com/balderdashy/sails/pull/375
