### PR TITLE
Allowing the assets.js helper to add a single asset by it's filename

### DIFF
--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -151,7 +151,6 @@ var Rack = rack.Rack.extend({
 		return out;
 	},
 	asset: function(assetName, opts) {
-		console.log(assetName)
 		var out = '';
 		var isProduction = (sails.config.environment == 'production');
 


### PR DESCRIPTION
This patch adds an option to include a single css or js file via it's file name without it's extension, for example: assets.js("/app"). For backwards compatibility, given no file name assets.js() will load all files like it did before.

Coming from Rails to node I wanted a sprokets-like asset mechanism where I could add a single asset to the html and order my dependencies via @import or //= require. This patch enables the @import style of dependency definition in stylus. I will send a separate pull request for snocketAssets to enable //=require in js/cs files.

Hopefully I'm not overloading you guys with pull requests. I'm setting up my first Sails environment today so theres been a number of changes I needed to get things working with my preferred frontend stack.

Cheers,
Rob

Originally https://github.com/balderdashy/sails/pull/374
