### PR TITLE
Add support for pre-static middleware

### DIFF
--- a/lib/configuration/express.js
+++ b/lib/configuration/express.js
@@ -98,6 +98,11 @@ exports.configure = function configure(cb) {
 
 		function afterwards(err) {
 
+			// Allow usage of custom express middleware
+			if (sails.config.express.preStaticCustomMiddleware) {
+				sails.config.express.preStaticCustomMiddleware(sails.express.app);
+			}
+
 			// Static middleware configuration
 			var staticDirs = sails.config.paths['public'];
 			var staticOptions = {};


### PR DESCRIPTION
Some middleware needs to be executed prior to express.static.  This pull request adds support for that, and mitigates the need for [app.stack abuse](http://www.exratione.com/2013/03/nodejs-abusing-express-3-to-enable-late-addition-of-middleware/).

Use case: Less-middleware will never recompile .less files in static directories unless it's listed above express.static in the middleware stack.

For reference: https://github.com/emberfeather/less.js-middleware#troubleshooting
