### PR TITLE
Fix model template

### DIFF
--- a/bin/boilerplates/templates/model.ejs
+++ b/bin/boilerplates/templates/model.ejs
@@ -4,7 +4,7 @@
 ---------------------*/
 module.exports = {
 
-	attributes	: {
+	attributes: {
 
 		// Simple attribute:
 		// name: 'STRING',
@@ -12,7 +12,7 @@ module.exports = {
 		// Or for more flexibility:
 		// phoneNumber: {
 		//	type: 'STRING',
-		//	defaultValue: '555-555-5555'
+		//	defaultsTo: '555-555-5555'
 		// }
 		<%- attributes %>
 	}


### PR DESCRIPTION
This fixes the model template by using the 'defaultsTo' syntax instead of 'defaultValue'.
