### PR TITLE
Allow mongo to be used as a session store

### DIFF
--- a/bin/boilerplates/config/session.js
+++ b/bin/boilerplates/config/session.js
@@ -4,6 +4,11 @@ module.exports.session = {
 	// It can be easily replaced here:
 	secret: '2f6f6c69398ae61b2edea014ce78b1bb',
 
+	// Uncomment the following lines to use your Mongo adapter as a session store
+	// Information about setting up a Mongo adapter can be found here: https://github.com/balderdashy/sails-mongo
+	// adapter: 'mongo',
+	// url: require('./adapters').adapters.mongo.url
+
 	// In production, uncomment the following lines to set up a shared redis session store
 	// that can be shared across multiple Sails.js servers
 	// adapter: 'redis'

--- a/lib/configuration/build.js
+++ b/lib/configuration/build.js
@@ -18,14 +18,17 @@ module.exports = function (defaults,userConfig) {
 	result.session	= _.extend(defaults.session,userConfig.session || {});
 	
 	// Intepret session adapter config
-    if (_.isObject(result.session)) {
-	    if (result.session.adapter === 'memory' && !_.isObject(result.session.store)) {
-	        result.session.store = new (require('express').session.MemoryStore)();
-	    }
-	    if (result.session.adapter === 'redis') {
-	        result.session.store = new (require('connect-redis')(require('express')))(result.session);
-	    }
-    }
+	if (_.isObject(result.session)) {
+		if (result.session.adapter === 'memory' && !_.isObject(result.session.store)) {
+			result.session.store = new (require('express').session.MemoryStore)();
+		}
+		if (result.session.adapter === 'redis') {
+			result.session.store = new (require('connect-redis')(require('express')))(result.session);
+		}
+		if (result.session.adapter === 'mongo') {
+			result.session.store = new (require('connect-mongo')(require('express')))(result.session);
+		}
+	}
 
 	result.cache	= _.extend(defaults.cache,userConfig.cache || {});
 	result.express	= _.extend(defaults.express,userConfig.express || {});

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "coffee-script": "1.6.2",
     "connect-redis": "1.4.5",
     "hbs": "2.1.0",
-    "cookie": "0.0.6"
+    "cookie": "0.0.6",
+    "connect-mongo": "0.3.2"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Basic support for using Mongo as a session store.  Default setup assumes the user has already set up a Mongo adapter using [sails-mongo](https://github.com/balderdashy/sails-mongo), but this can be overridden in the session.js config.
