### PR TITLE
added support for missing replaceVal in sails.modules loader

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -65,7 +65,7 @@ function buildDictionary(options) {
 				// If no 'identity' attribute was provided, 
 				// take a guess based on the (case-insensitive) filename
 				if(!module.identity) {
-					module.identity = options.replaceExpr ? filename.replace(options.replaceExpr, "") : filename;
+					module.identity = options.replaceExpr ? filename.replace(options.replaceExpr, options.replaceVal || "") : filename;
 					
 					module.globalId = module.identity;
 					module.identity = module.identity.toLowerCase();


### PR DESCRIPTION
`buildDictionary` function in the loader module should support `options.replaceVal` as per documented available options.

This pull request implements the missing `options.replaceVal` when generating `module.identity`, defaulting to the existing empty string if non is supplied
