### PR TITLE
First run at geneating tests.

### DIFF
--- a/bin/boilerplates/templates/api-test-methods.ejs
+++ b/bin/boilerplates/templates/api-test-methods.ejs
@@ -1,0 +1,29 @@
+	describe('<%- action %> method', function () {
+
+		describe('GET /', function () {
+
+			it('responds with HTTP 200', function(done){
+				// supertest allows us to pass in the express app - and not have to worry about host:ports
+				request(app) // app
+					.get('/<%- controller %>/<%- action %>')
+					.expect(200, done);
+			});
+
+			it('respond properly when no-content type is set', function(done){
+				request(app) // app
+					.get('/<%- controller %>/<%- action %>')
+					.expect(/generated successfully and ready to go!/, done); // If generate some base templates - we can put something more appropriate in here
+			});
+
+			it('respond properly when content-type is set to json', function(done){
+				request(app) // app
+					.get('/<%- controller %>/<%- action %>')
+					.set('Accept', 'application/json')
+					.expect('Content-Type', /json/)
+					.expect(JSON.stringify({"content": "generated successfully and ready to go!"}))
+					.expect(200, done)
+			});
+
+		});
+
+	});

--- a/bin/boilerplates/templates/api-test.ejs
+++ b/bin/boilerplates/templates/api-test.ejs
@@ -1,0 +1,28 @@
+var request = require('supertest'),
+	sailsHelper = require("../helpers/sailsHelper");
+
+describe('<%- entity %> Controller', function(){
+
+	// Reference for the app
+	var app;
+
+	before(function(done){
+		sailsHelper.init(
+			function(){
+				// Attach to the app
+				app = sails.express.app;
+				// drop the logging level - keep it clean
+				sails.config.log.level = "warn";
+				// Looks like we're up
+				done();
+			}
+		);
+	});
+
+	after(function(done){
+		sailsHelper.lower(done);
+	});
+
+<%- actions %>
+
+});

--- a/bin/boilerplates/test/helpers/sailsHelper.js
+++ b/bin/boilerplates/test/helpers/sailsHelper.js
@@ -1,0 +1,56 @@
+"use strict";
+var sails = null,
+	isLifted = false;
+
+module.exports = {
+	buildOptions: function() {
+		var _ = require("lodash"),
+			opts = require('optimist').argv;
+
+		// Reduce logging
+		opts.log = {
+			level: "warn"
+		};
+
+		// A little ott maybe - but lets knock up a table of ports
+		var portSet = [];
+		for(var i=0;i<10;i++) {
+			portSet.push(1024+Math.ceil(Math.random()*64511));
+		}
+		// pick one of them
+		//opts.port = _.min(portSet);
+		opts.port = portSet[Math.ceil(Math.random()*10)];
+
+		return opts;
+	},
+	lower: function(done){
+		//console.log("Lowering Sails");
+		//sails.lower();
+		if (done && typeof done==="function") {
+			done();
+		}
+	},
+	raise: function(opts, done){
+
+		if (!isLifted) {
+			sails.lift(opts,
+				function(){
+					// lifted
+					isLifted = true;
+					done();
+				}
+			);
+		} else {
+			done();
+		}
+	},
+	init: function (done) {
+		if (sails && typeof sails !== 'undefined') {
+			//
+		} else {
+			sails = require('sails');
+		}
+
+		this.raise(this.buildOptions(), done);
+	}
+}

--- a/bin/boilerplates/test/mocha.opts
+++ b/bin/boilerplates/test/mocha.opts
@@ -1,0 +1,4 @@
+--reporter spec
+--recursive
+--growl
+--require should

--- a/bin/new.js
+++ b/bin/new.js
@@ -63,6 +63,7 @@ module.exports = function createNewApp(appName, templateLang) {
 	// Create default app structure
 	utils.copyBoilerplate('assets', outputPath + '/assets');
 	utils.copyBoilerplate('api', outputPath + '/api');
+	utils.copyBoilerplate('test', outputPath + '/test');
 	utils.copyBoilerplate('config', outputPath + '/config', function () {
 
 		// Generate session secret
@@ -70,9 +71,9 @@ module.exports = function createNewApp(appName, templateLang) {
 		var newSessionConfig = ejs.render(fs.readFileSync(boilerplatePath, 'utf8'), {
 			secret: require('../lib/session/generateSecret')()
 		});
-		
+
 		fs.writeFileSync(outputPath + '/config/session.js', newSessionConfig, 'utf8');
-		
+
 	});
 
 
@@ -116,7 +117,8 @@ module.exports = function createNewApp(appName, templateLang) {
 			// Include this later when we have "sails test" ready.
 			// test: './node_modules/mocha/bin/mocha -b',
 			start: 'node app.js',
-			debug: 'node debug app.js'
+			debug: 'node debug app.js',
+			test: "mocha test/controller/"
 		},
 		main: 'app.js',
 		repository: '',
@@ -143,7 +145,7 @@ module.exports = function createNewApp(appName, templateLang) {
 	// Copy Sails itself into new project as a local dependency
 	//
 	// TODO:	examine using a symbolic link for the node_modules
-	// 			instead of copying the directory over directly, 
+	// 			instead of copying the directory over directly,
 	//			since it would be much quicker, and wouldn't hurt anything
 	utils.copySails(outputPath + '/node_modules/sails');
 };

--- a/bin/sails.js
+++ b/bin/sails.js
@@ -188,6 +188,19 @@ else if (argv._[0] && (argv._[0].match(/^g$|^ge$|^gen$|^gene$|^gener$|^genera$|^
 		var options = _.extend({}, argv);
 		generate.generateAdapter(entity, options);
 	}
+
+	// Generate an adapter
+	else if (argv._[1] === 'test') {
+		var entity = argv._[2];
+		verifyArg(2, "Please specify the name for the new test as the third argument.");
+
+		// Figure out actions based on args
+		var options = _.extend({}, argv);
+		options.actions = argv._.splice(3);
+
+		generate.generateTest(entity, options);
+	}
+
 	// Otherwise generate a model and controller
 	else {
 		var entity = argv._[1];
@@ -250,6 +263,7 @@ function sailsUsage() {
 	usage += leftColumn('sails generate <foo>') + 'Generate api/models/Foo.js and api/controllers/FooController.js\n';
 	usage += leftColumn('sails generate model <foo>') + 'Generate api/models/Foo.js\n';
 	usage += leftColumn('sails generate controller <foo>') + 'Generate api/controllers/FooController.js\n';
+	usage += leftColumn('sails generate test <foo>') + 'Generate test/controller/FooController.js\n';
 	usage += leftColumn('sails version') + 'Get the current globally installed Sails version';
 
 	sails.log.info(usage);

--- a/lib/configuration/defaults.js
+++ b/lib/configuration/defaults.js
@@ -5,7 +5,7 @@ module.exports = function (userConfig) {
 
 	// If appPath not specified, use process.cwd() to get the app dir
 	userConfig.appPath = userConfig.appPath || process.cwd();
-	
+
 	// Paths for application modules and key files
 	var paths = {
 		app				: userConfig.appPath,
@@ -25,7 +25,8 @@ module.exports = function (userConfig) {
 		templates		: paths.app + '/assets/templates',
 		dependencies	: paths.app + '/dependencies',
 		views			: paths.app + '/views',
-		layout			: paths.app + '/views/layout.ejs'
+		layout			: paths.app + '/views/layout.ejs',
+		tests 			: paths.app + '/test'
 
 	});
 
@@ -162,7 +163,7 @@ module.exports = function (userConfig) {
 
 		// Custom options for express server
 		express: {
-			
+
 			// Sails extras
 			serverOptions: null,
 			customMiddleware: null,
@@ -179,7 +180,7 @@ module.exports = function (userConfig) {
 			// (`undefined` indicates default memory store)
 			// NOTE: Default memory store will not work for clustered deployments with multiple instances.
 			adapter: undefined,
-			
+
 			// A array of allowed transport methods which the clients will try to use.
 			// The flashsocket transport is disabled by default
 			// You can enable flashsockets by adding 'flashsocket' to this list:
@@ -215,17 +216,17 @@ module.exports = function (userConfig) {
 			// Enable the flash policy server if the flashsocket transport is enabled
 			'flash policy server': true,
 
-			// By default the Socket.IO client will check port 10843 on your server 
+			// By default the Socket.IO client will check port 10843 on your server
 			// to see if flashsocket connections are allowed.
-			// The Adobe Flash Player normally uses 843 as default port, 
+			// The Adobe Flash Player normally uses 843 as default port,
 			// but Socket.io defaults to a non root port (10843) by default
 			//
 			// If you are using a hosting provider that doesn't allow you to start servers
-			// other than on port 80 or the provided port, and you still want to support flashsockets 
+			// other than on port 80 or the provided port, and you still want to support flashsockets
 			// you can set the `flash policy port` to -1
 			'flash policy port': 10843,
 
-			// Used by the HTTP transports. The Socket.IO server buffers HTTP request bodies up to this limit. 
+			// Used by the HTTP transports. The Socket.IO server buffers HTTP request bodies up to this limit.
 			// This limit is not applied to websocket or flashsockets.
 			'destroy buffer size': '10E7',
 
@@ -245,34 +246,34 @@ module.exports = function (userConfig) {
 			// Does Socket.IO need to send an ETag header for the static requests?
 			'browser client etag': false,
 
-			// Adds a Cache-Control: private, x-gzip-ok="", max-age=31536000 header to static requests, 
+			// Adds a Cache-Control: private, x-gzip-ok="", max-age=31536000 header to static requests,
 			// but only if the file is requested with a version number like /socket.io/socket.io.v0.9.9.js.
 			'browser client expires': 315360000,
 
 			// Does Socket.IO need to GZIP the static files?
-			// This process is only done once and the computed output is stored in memory. 
+			// This process is only done once and the computed output is stored in memory.
 			// So we don't have to spawn a gzip process for each request.
 			'browser client gzip': false,
-			
+
 			// A function that should serve all static handling, including socket.io.js et al.
 			'browser client handler': false,
 
-			// Meant to be used when running socket.io behind a proxy. 
-			// Should be set to true when you want the location handshake to match the protocol of the origin. 
-			// This fixes issues with terminating the SSL in front of Node 
+			// Meant to be used when running socket.io behind a proxy.
+			// Should be set to true when you want the location handshake to match the protocol of the origin.
+			// This fixes issues with terminating the SSL in front of Node
 			// and forcing location to think it's wss instead of ws.
 			'match origin protocol' : false,
 
-			// Global authorization for Socket.IO access, 
+			// Global authorization for Socket.IO access,
 			// this is called when the initial handshake is performed with the server.
-			// 
+			//
 			// By default, Sails verifies that a valid cookie was sent with the upgrade request
 			// However, in the case of cross-domain requests, no cookies are sent for some transports,
 			// so sockets will fail to connect.  You might also just want to allow anyone to connect w/o a cookie!
-			// 
+			//
 			// To bypass this cookie check, you can set `authorization: false`,
 			// which will silently create an anonymous cookie+session for the user
-			// 
+			//
 			// `authorization: true` indicates that Sails should use the built-in logic
 			//
 			// You can also use your own custom logic with:
@@ -300,7 +301,7 @@ module.exports = function (userConfig) {
 			// (`undefined` indicates use default)
 			'static': undefined,
 
-			// The entry point where Socket.IO starts looking for incoming connections. 
+			// The entry point where Socket.IO starts looking for incoming connections.
 			// This should be the same between the client and the server.
 			resource: '/socket.io'
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "grunt-contrib-watch": "~0.4.4",
     "mocha": "*",
     "request": "*",
+    "should": "*",
+    "supertest": "*",
     "ejs": "~0.8.4",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-cssmin": "~0.6.1",


### PR DESCRIPTION
Currently this works for controllers.  

You can run: 'sails generate test <controllername>' to generate tests for all actions in a controller.  
Supports 'sails generate test <controllername> --force' to overwrite the test.  
Optionally you can use 'sails generate test <controllername> actionOne ActionTwo' to only generate tests for those actions - actions are checked to ensure they exist.

Todo:
1) Better base tests - the current ones depend on the view actually existing and the default routes (as listed in the controller when generated) to work
2) Some form of require in tests that allow users to write their own tests for controllers - and for generated tests to still work.  ie: sails generate test controller to be run multiple times without destroying any extra tests created by users.
3) Grunt helpers for running tests
4) bringing tests fully into the dev experience - with some kind of base for viewing tests & their results in the browser.  Make it pretty, give 'em metrics & coverage and they'll drool
