### PR TITLE
remove node-dirty note from adapters.js boilerplate

### DIFF
--- a/bin/boilerplates/config/adapters.js
+++ b/bin/boilerplates/config/adapters.js
@@ -16,9 +16,6 @@ module.exports.adapters = {
 
 	// Persistent adapter for DEVELOPMENT ONLY
 	// (data IS preserved when the server shuts down)
-	// PLEASE NOTE: disk adapter not compatible with node v0.10.0 currently 
-	//				because of limitations in node-dirty
-	//				See https://github.com/felixge/node-dirty/issues/34
 	disk: {
 		module: 'sails-dirty',
 		filePath: './.tmp/dirty.db',


### PR DESCRIPTION
@bentaber & @mikermcneil fixed this in Issue #245 & felixge/node-dirty#34
