### PR TITLE
Move ejs from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,12 +59,12 @@
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-cssmin": "~0.6.1",
     "grunt-contrib-less": "~0.5.2",
-    "parley": "0.0.2"
+    "parley": "0.0.2",
+    "ejs": "~0.8.4"
   },
   "devDependencies": {
     "mocha": "*",
-    "request": "*",
-    "ejs": "~0.8.4"
+    "request": "*"
   },
   "optionalDependencies": {
     "coffee-script": "1.6.2"


### PR DESCRIPTION
Running `sails new test` gave me the following error in 0.9.

``` bash
Error: Cannot find module 'ejs'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at module.exports (/usr/local/share/npm/lib/node_modules/sails/bin/utils.js:8:10)
    at /usr/local/share/npm/lib/node_modules/sails/bin/sails.js:14:33
    at /usr/local/share/npm/lib/node_modules/sails/lib/configuration/load.js:110:4
    at /usr/local/share/npm/lib/node_modules/sails/node_modules/async/lib/async.js:422:17
    at /usr/local/share/npm/lib/node_modules/sails/node_modules/async/lib/async.js:416:17
    at Array.forEach (native)
```

Looks like the cli relies on ejs so I moved it to dependencies in the package.json.
