### PR TITLE
Deep merge on Config Objects

### DIFF
--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -109,7 +109,7 @@ function Sails () {
 		var sails = this;
 
 		// Stow CLI/env override
-		this.config = _.clone(configOverride || {});
+		this.config = configOverride || {};
 
 		async.series([
 			

--- a/lib/configuration/build.js
+++ b/lib/configuration/build.js
@@ -5,28 +5,9 @@ module.exports = function(sails) {
 	 */
 
 	var _ = require('lodash');
-
+	var deepMerge = require('../util').deepMerge;
 
 	/**
-	 * Recursively merge objects
-	 */
-
-	function deepMerge(target, source) {
-		for (var key in source) {
-			var original = target[key];
-			var next = source[key];
-			if (original && next && typeof next == "object") {
-				deepMerge(original, next);
-			} else {
-				if (next) target[key] = next;
-			}
-		}
-		return target;
-	}
-
-
-
-	/** 
 	 * Extend defaults with user config
 	 */
 
@@ -63,12 +44,12 @@ module.exports = function(sails) {
 			}
 		}
 
-		result.cache = _.extend(defaults.cache, userConfig.cache || {});
+		result.cache = deepMerge(defaults.cache, userConfig.cache || {});
 		result.express = _.extend(defaults.express, userConfig.express || {});
-		result.log = _.extend(defaults.log, userConfig.log || {});
-		result.globals = _.extend(defaults.globals, userConfig.globals || {});
-		result.paths = _.extend(defaults.paths, userConfig.paths || {});
-		result.adapters = _.extend(defaults.adapters, userConfig.adapters || {});
+		result.log = deepMerge(defaults.log, userConfig.log || {});
+		result.globals = deepMerge(defaults.globals, userConfig.globals || {});
+		result.paths = deepMerge(defaults.paths, userConfig.paths || {});
+		result.adapters = deepMerge(defaults.adapters, userConfig.adapters);
 		result.io = _.extend(defaults.io, userConfig.io || {});
 
 		// Only build serverOptions if SSL is specified

--- a/lib/configuration/load.js
+++ b/lib/configuration/load.js
@@ -7,10 +7,9 @@ module.exports = function (sails) {
 	var _			= require( 'lodash' ),
 	async			= require('async'),
 	CaptainsLog		= require('../logger')(sails),
-	ModuleLoader	= require('../moduleloader');
+	ModuleLoader	= require('../moduleloader'),
+	deepMerge = require('../util').deepMerge;
 
-	
-	
 	/**
 	 * Expose Configuration loader
 	 */
@@ -61,18 +60,18 @@ module.exports = function (sails) {
 				}
 
 				// Extend with whatever's in sails.config (CLI or env override)
-				userConfig = _.extend(userConfig, sails.config || {});
+				userConfig = deepMerge(userConfig, sails.config);
 
 				// Merge user config with defaults
-				sails.config = _.extend(sails.config,self.build(self.defaults(userConfig), userConfig));
+				sails.config = deepMerge(sails.config, self.build(self.defaults(userConfig), userConfig));
 
 				// Validate user config
 				sails.config = self.validate(sails.config, userConfig);
 
 
 				// Expose route config and policy tree, and mixin defaults
-				sails.config.policies = _.extend({ "*" : true },sails.config.policies);
-				sails.routes = _.extend({},sails.config.routes);
+				sails.config.policies = deepMerge({ "*" : true }, sails.config.policies);
+				sails.routes = sails.config.routes || {};
 
 				cb();
 			},

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -5,6 +5,22 @@ _.str = require('underscore.string');
 //   return _.isFinite(id) || /^[0-9a-f]{24}$/.test(id);
 // };
 
+/**
+ * Recursively merge objects
+ */
+
+exports.deepMerge = function deepMerge(target, source) {
+	for (var key in source) {
+		var original = target[key];
+		var next = source[key];
+		if (original && next && typeof next == "object") {
+			deepMerge(original, next);
+		} else {
+			if (next) target[key] = next;
+		}
+	}
+	return target;
+};
 
 
 // Detect verb in an expression like: `get baz` or `get /foo/baz`


### PR DESCRIPTION
Allow a deepMerge to be used on certain config objects. It also uses the callback in Sails.lower() for use with Unit tests.
