### PR TITLE
Fixed bug when unbinding routes in Sails router

### DIFF
--- a/lib/express/index.js
+++ b/lib/express/index.js
@@ -104,6 +104,19 @@ module.exports = function (sails) {
 			app[route.verb || 'all'](route.path, route.target);
 		});
 
+		// When Sails unbinds routes, remove them from the internal Express router
+		sails.on('router:unbind', function (path, method) {
+
+			var newRoutes = [];
+			_.each(app.routes[method], function(expressRoute) {
+				if (expressRoute.path != path) {
+					newRoutes.push(expressRoute);
+				}
+			});
+			app.routes[method] = newRoutes;
+
+		});		
+
 		// When Sails is finished routing, add a custom error handler
 		sails.on('router:done', function () {
 

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -169,7 +169,14 @@ module.exports = function(sails) {
 			sails.emit('router:unbind', route);
 
 			// Remove route in internal router
-			expressApp.routes[route.verb].splice(index, 1);
+			var newRoutes = [];
+			_.each(expressApp.routes[route.method], function(expressRoute) {
+				if (expressRoute.path != route.path) {
+					newRoutes.push(expressRoute);
+				}
+			});
+			expressApp.routes[route.method] = newRoutes;
+
 		};
 
 


### PR DESCRIPTION
Fixed bug when unbinding routes in Sails router; using array.splice doesn't work when looping over an array, since the indexes change as items are removed.

Added "router:unbind" event handler in Sails express module to remove unbound routes from internal Express router.
