### PR TITLE
Schema True/False flag

### DIFF
--- a/lib/hooks/orm/index.js
+++ b/lib/hooks/orm/index.js
@@ -107,11 +107,25 @@ module.exports = function(sails) {
 
 	function loadCollection(model, cb) {
 
-		// Wrap model in Waterline.Collection.extend
-		var Model = Waterline.Collection.extend(sails.models[model]);
+		// Determine if model is schema or schemaless
+		var modelAdapters = sails.models[model].adapter;
+
+		// Check if main model adapter config has a default schema setting
+		var defaultSchema = sails.adapters[modelAdapters[0]].config.hasOwnProperty('schema');
+
+		// Check if the model is overriding the schema setting
+		var overrideSchema = typeof sails.models[model].schema !== 'undefined';
+
+		// Set the schema value if there is a default and nothing is overriding it
+		if(defaultSchema && !overrideSchema) {
+			sails.models[model].schema = sails.adapters[modelAdapters[0]].config.schema;
+		}
 
 		// Mixin local model defaults to the adapters passed into the model
 		var adapters = util.overrideConfig(model);
+
+		// Wrap model in Waterline.Collection.extend
+		var Model = Waterline.Collection.extend(sails.models[model]);
 
 		new Model({
 


### PR DESCRIPTION
This allows a flag to be set that will allow arbitrary data keys to be persisted in schemaless databases.

There are a few ways of defining it. If an adapter supports schemaless it can set it's default `schema` flag to false and this will allow anything to be persisted. This should be the default for the disk and memory adapters.

You can set it on a per model basis:

``` javascript
module.exports = {
   schema: false,
   attributes: {}
}
```

Or you can set it globally in the adapters.js config:

``` javascript
module.exports.adapters = {
    mongo: {
        schema: false
    }
}
```

It's already pushed to Waterline and I'll push it to the disk, memory and mongo adapters after this.
