### PR TITLE
Optionally override websockets authorization

### DIFF
--- a/lib/sails.js
+++ b/lib/sails.js
@@ -443,7 +443,7 @@ function initSails(cb) {
 			}
 			
 			// Configure auth for ws(s):// server
-			io.set('authorization', function(data, accept) {
+      io.set('authorization', (sails.config.websockets && sails.config.websockets.authorization) ? sails.config.websockets.authorization : function(data, accept) {
 				// If a cookie was provided in the query string, use it.
 				if (data.query.cookie) {
 					data.headers.cookie = data.query.cookie;


### PR DESCRIPTION
I'm using OAuth2 bearer tokens in the Express middleware, so my API clients do not use cookies.

This breaks paradigm for Sails websockets, and because the current socket.io authorization function is non-configurable, I can't specify my own authorization function based on bearer tokens.

This baby diff just passes in a custom authorization function if it exists, otherwise it defaults to the standard session-based authorization.
