### PR TITLE
Re-added back in res.view layout attribute.

### DIFF
--- a/lib/hooks/views/index.js
+++ b/lib/hooks/views/index.js
@@ -268,7 +268,8 @@ module.exports = function (sails) {
 				// Figure out if this is a subview or a top-level view
 				// And determine the relative path to the layout file accordingly
 				var isSubView = ( (path.split('/')).length > 1 );
-				var relativePathToLayout = (isSubView ? '../' : '') + sails.config.views.layout;
+				var layout = (data.layout) ? data.layout : sails.config.views.layout ;
+				var relativePathToLayout = (isSubView ? '../' : '') + layout;
 
 				// Determine the layout to use
 				sails.log.verbose('Rendering layout at: ', relativePathToLayout);


### PR DESCRIPTION
Hey,

I was playing around with the new 0.9-RC and my

```
res.view('file', { layout: 'test' });
```

was not working as it was being overwrote. I re-added this back in.

On another note, is there a reason that

```
<% layout('boilerplate') -%>
```

Doesn't work?
