### PR TITLE
When installing in an existing directory, take the existing settings in package.json and merge them into the generated file

### DIFF
--- a/bin/new.js
+++ b/bin/new.js
@@ -120,8 +120,16 @@ module.exports = function (sails) {
 		utils.generateFile('gitignore', outputPath + '/.gitignore');
 
 		// Generate package.json
+		var basePackage = {};
+
+		// If installing in an existing directory and package.json file exists,
+		// take its contents and use it in a merge
+		if (existingDirectory && fs.existsSync(outputPath + '/package.json')) {
+			basePackage = JSON.parse(fs.readFileSync(outputPath + '/package.json', 'utf8'));
+		}
+
 		sails.log.debug('Generating package.json...');
-		fs.writeFileSync(outputPath + '/package.json', JSON.stringify({
+		fs.writeFileSync(outputPath + '/package.json', JSON.stringify(_.merge({
 			name: appName,
 			'private': true,
 			version: '0.0.0',
@@ -141,7 +149,7 @@ module.exports = function (sails) {
 			repository: '',
 			author: '',
 			license: ''
-		}, null, 4));
+		}, basePackage), null, 4));
 
 		// Copy Gruntfile
 		sails.log.debug('Generating Gruntfile...');

--- a/test/cli/integration/new.test.js
+++ b/test/cli/integration/new.test.js
@@ -80,6 +80,30 @@ describe('New app generator', function() {
 				});
 			});
 		});
+
+		it('should merge existing package.json', function(done) {
+      
+			// make app folder and move into directory
+			fs.mkdirSync(appName);
+			process.chdir(appName);
+
+			fs.writeFileSync('./package.json', JSON.stringify({
+				'name': 'Custom App Name'
+			}));
+
+			exec( '.' + sailsbin + ' new .', function(err) {
+				if (err) { done(new Error(err)); }
+
+				var packageContent = fs.readFileSync('./package.json', 'utf8');
+				assert(packageContent.indexOf('Custom App Name') !== -1, 'package.json was not merged correctly');
+
+				// move from app to its parent directory
+				process.chdir('../');
+
+				done();
+			});
+
+		});
 	});
 
 	describe('sails new with no template option', function() {


### PR DESCRIPTION
I'm relatively new to Node so I've been playing with a few different frameworks for an app I'm building. Consequently, I had both an existing directory and an existing `package.json` file containing some devDependencies and a few other attributes that I'd like to keep. Ideally, for me, Sails would see my package.json and merge it into its own defaults. So that's what I wrote!

I also tried to update the `new.test.js` to reflect some big changes that have happened in the project so I could get all the tests passing before opening this PR.

Since `node_modules` gets copied into the project now the `checkGeneratedFiles` function was failing and it made comparing the directory structures slow and essentially impossible. So I changed it to check the expected files one by one and if any file isn't there it returns false.

Then I went through and tried to remove pieces that were no longer relevant as `new` didn't seem to generate a number of the expected files anymore, along with removing the tests for handlebars and haml as I gathered they were no longer supported.

Hope this isn't a complete waste and let me know what you think! :D
