### PR TITLE
0.9: Fix error when Accept header doesn't exist in request

### DIFF
--- a/lib/hooks/request/index.js
+++ b/lib/hooks/request/index.js
@@ -184,9 +184,10 @@ module.exports = function (sails) {
 	 */
 
 	function _mixinReqQualifiers (req,res) {
+		var accept = req.get('Accept') || '';
 
 		// Flag indicating whether HTML was explicitly mentioned in the Accepts header
-		req.explicitlyAcceptsHTML = (req.get('Accept').indexOf('html') !== -1);
+		req.explicitlyAcceptsHTML = (accept.indexOf('html') !== -1);
 
 		// Flag indicating whether a request would like to receive a JSON response
 		req.wantsJSON =	req.xhr;


### PR DESCRIPTION
Fixes most tests that are failing after #579
