### PR TITLE
0.9: Parse string socket data as JSON before determining verb.

### DIFF
--- a/lib/hooks/sockets/interpreter/getVerb.js
+++ b/lib/hooks/sockets/interpreter/getVerb.js
@@ -6,6 +6,13 @@ module.exports = function getVerb (socketIOData, messageName) {
 		return messageName;
 	}
 
+	if (_.isString(socketIOData)) {
+		try {
+			socketIOData = JSON.parse(socketIOData);
+		} catch(e) {
+		}
+	}
+
 	if (_.isString(socketIOData.verb)) {
 		return socketIOData.verb.toLowerCase();
 	}


### PR DESCRIPTION
Socket.io requests come in as JSON but the verb is extracted before parsing the string as an object. This may not be the "correct" place to do this, but it fixes socket request routing for now.
