### PR TITLE
Declare socketConfig variable

### DIFF
--- a/lib/hooks/sockets/configure.js
+++ b/lib/hooks/sockets/configure.js
@@ -138,6 +138,8 @@ module.exports = function (sails) {
 
 	function createRedisConnection(port, host) {
 
+		var socketConfig = sails.config.sockets;
+
 		// Create a new client using the port, host and other options
 		var client = Redis.createClient(port, host, socketConfig);
 


### PR DESCRIPTION
Fixes `ReferenceError: socketConfig is not defined` when using Redis pubsub
