### PR TITLE
Ensure the type of id is maintained when publishing changes.

### DIFF
--- a/lib/hooks/controllers/controller.destroy.js
+++ b/lib/hooks/controllers/controller.destroy.js
@@ -50,7 +50,7 @@ module.exports = function (sails) {
 				// If the model is silent, don't use the built-in pubsub
 				// (also ignore pubsub logic if the hook is not enabled)
 				if (sails.config.hooks.pubsub && !Model.silent) {
-					Model.publishDestroy(result, req.socket);
+					Model.publishDestroy(result.id, req.socket);
 				}
 
 				// Respond with model which was destroyed

--- a/lib/hooks/controllers/controller.update.js
+++ b/lib/hooks/controllers/controller.update.js
@@ -48,7 +48,7 @@ module.exports = function (sails) {
 			// If the model is silent, don't use the built-in pubsub
 			// (also ignore pubsub logic if the hook is not enabled)
 			if (sails.config.hooks.pubsub && !Model.silent) {
-				Model.publishUpdate(id, model.toJSON(), req.socket);
+				Model.publishUpdate(model.id, model.toJSON(), req.socket);
 			}
 
 			return res.json(model.toJSON());


### PR DESCRIPTION
If the id from params is used in the publish call, the id will always be a string. This PR maintains the real type of the model id when publishing changes. The `publishCreate` method already maintains the type since it grabs the id straight from the model instance in `introduce`.

This also fixes #621 which I've closed.
