### PR TITLE
for models, load only javascript or coffeescript files

### DIFF
--- a/lib/hooks/orm/modules.js
+++ b/lib/hooks/orm/modules.js
@@ -25,7 +25,7 @@ module.exports = function(sails) {
 				// Case-insensitive, using filename to determine identity
 				sails.models = Modules.optional({
 					dirname		: sails.config.paths.models,
-					filter		: /(.+)\..+$/
+					filter		: /(.+)\.(js|coffee)$/
 				});
 
 				cb();


### PR DESCRIPTION
i had a swap file in the models folder and sails was trying to load it which was causing my ship to crash. This fixes the problem.
