### PR TITLE
+ escape spaces in pathToSails

### DIFF
--- a/lib/grunt/index.js
+++ b/lib/grunt/index.js
@@ -5,7 +5,7 @@ module.exports = function (sails) {
 		var environment = sails.config.environment;
 		var baseurl = 'http://' + sails.config.host + ':' + sails.config.port;
 		var signalpath = '/___signal';
-		var pathToSails = __dirname + '/../..';
+		var pathToSails = __dirname.replace(' ', '\\ ') + '/../..';
 
 		if (!taskName) {
 			taskName = '';


### PR DESCRIPTION
When spawning the child process to run grunt during `sails lift`, escape spaces in `__dirname` so grunt doesn't fail.
