### PR TITLE
Alternate form for config.views.engine format.

### DIFF
--- a/bin/boilerplates/config/views.js
+++ b/bin/boilerplates/config/views.js
@@ -26,7 +26,13 @@ module.exports.views = {
 
   engine: 'ejs',
 
-
+  // Alternate configuration format to enable use of various consolidate
+  // supported engines.
+  //
+  // engine: {
+  //     ext: 'html',
+  //     fn: require('consolidate').swig
+  // },
 
   // Layouts are simply top-level HTML templates you can use as wrappers 
   // for your server-side views.  If you're using ejs, you can take advantage of

--- a/lib/express/index.js
+++ b/lib/express/index.js
@@ -49,22 +49,38 @@ module.exports = function (sails) {
 		sails.express.app.set('views', sails.config.paths.views);
 
 		var engine = sails.config.views.engine;
-		var depPath = sails.config.appPath + '/node_modules/' + engine;
-		var engineModule;
-		try {
-			engineModule = require(depPath);
-		}
-		catch (e) {
-			if (e) {
-				sails.log.error('Your configured server-side view engine (' + engine + ') could not be found.');
-				sails.log.error('You\'re probably just missing it as a dependency though.');
-				sails.log.error('To install ' + engine + ', run:  `npm install ' + engine + ' --save`');
-				throw e;
+		if (typeof engine === 'string') {
+			var depPath = sails.config.appPath + '/node_modules/' + engine;
+			var engineModule;
+			try {
+				engineModule = require(depPath);
 			}
-		}
+			catch (e) {
+				if (e) {
+					sails.log.error('Your configured server-side view engine (' + engine + ') could not be found.');
+					sails.log.error('You\'re probably just missing it as a dependency though.');
+					sails.log.error('To install ' + engine + ', run:  `npm install ' + engine + ' --save`');
+					throw e;
+				}
+			}
 
-		app.engine(engine, engineModule.__express);
-		sails.express.app.set('view engine', engine);
+			app.engine(engine, engineModule.__express);
+			sails.express.app.set('view engine', engine);
+
+		} else if (engine && engine.ext && engine.fn) {
+			app.engine(engine.ext, engine.fn);
+			app.set('view engine', engine.ext);
+
+		} else {
+			sails.log.error('Invalid templating engine configuration. `config.views.engine` should');
+			sails.log.error('be set to either a `string` or an `object` with the following properties:');
+			sails.log.error('    {');
+			sails.log.error('        ext: <string>,   // the file extension');
+			sails.log.error('        fn: <function>   // the template engine render function');
+			sails.log.error('    }');
+			sails.log.error('For example: {ext:"html", fn: require("consolidate").swig}');
+			sails.log.error('For details: http://expressjs.com/api.html#app.engine');
+		}
 
 		
 


### PR DESCRIPTION
Additional template engine config format for when `engineModule.__express` doesn't work.
