### PR TITLE
Fixes undefined function error thrown during model generation with schema

### DIFF
--- a/bin/utils.js
+++ b/bin/utils.js
@@ -280,7 +280,7 @@ module.exports = function(sails) {
 		 */
 
 		this.verifyValidEntity = function(entity, msg) {
-			if (!isValidECMA51Variable(entity)) {
+			if (!this.isValidECMA51Variable(entity)) {
 				sails.log.error(msg);
 				process.exit(1);
 			} else {


### PR DESCRIPTION
Fixes undefined function error thrown during model generation with schema:

$ sails generate model example name:string email:string
warn: For the record :: to serve the blueprint API for this model,
warn: you'll also need to have an empty controller.

/usr/local/lib/node_modules/sails/bin/utils.js:283
            if (!isValidECMA51Variable(entity)) {
                 ^
ReferenceError: isValidECMA51Variable is not defined
