### PR TITLE
Fix for policy mapping of actions with capitals, plus general integration test fixes.

### DIFF
--- a/lib/hooks/policies/index.js
+++ b/lib/hooks/policies/index.js
@@ -268,7 +268,7 @@ module.exports = function(sails) {
 			else {
 				util.each(actions, function(actionId) {
 
-					var actionPolicy = mapping[id][actionId];
+					var actionPolicy = mapping[id][actionId.toLowerCase()];
 					sails.log.verbose('Mapping policies to actions.... ', actions);
 
 					// If a policy doesn't exist for this controller, use the controller-local '*'

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --timeout 60000
 --reporter dot
 --ui bdd
+test/router/integration/policies.test.js
 node_modules/waterline/test/**/*.js

--- a/test/router/integration/fixtures/api/controllers/TestController.js
+++ b/test/router/integration/fixtures/api/controllers/TestController.js
@@ -25,5 +25,9 @@ module.exports = {
 
 	destroy: function(req, res) {
 		res.send('destroy');
-	}
+	},
+
+  CapitalLetters: function(req, res) {
+    res.send('CapitalLetters');
+  }
 };

--- a/test/router/integration/helpers/httpHelper.js
+++ b/test/router/integration/helpers/httpHelper.js
@@ -21,13 +21,12 @@ module.exports = {
 
 		// Start the sails server process
 		var sailsprocess = spawn('../bin/sails.js', ['lift']);
-
-		sailsprocess.stderr.on('data',function(data) {
+		sailsprocess.stdout.on('data',function(data) {
 			// Change buffer to string
 			var dataString = data + '';
 
 			// Make request once server has sucessfully started
-			if (dataString.match(/Sails \S+ lifted/)) {
+			if (dataString.match(/Server lifted/)) {
 
 				request[method](options, function(err, response) {
 					if (err) callback(err);

--- a/test/router/integration/policies.test.js
+++ b/test/router/integration/policies.test.js
@@ -40,8 +40,8 @@ describe('Policies', function() {
       httpHelper.testRoute('get', {url: 'test', headers: {'Content-Type': 'application/json'}, json: true}, function(err, response) {
         if (err) done(new Error(err));
 
-        assert(response.body instanceof Array);
-        assert.equal(response.body[0], 'Test Error');
+        assert.equal(response.body.status, 500);
+        assert.equal(response.body.errors[0].message, 'Test Error');
         done();
       });
     });
@@ -67,7 +67,8 @@ describe('Policies', function() {
         httpHelper.testRoute('get', {url: 'test', headers: {'Content-Type': 'application/json'}, json: true}, function(err, response) {
           if (err) done(err);
 
-          assert.equal(response.body[0], 'Test Error');
+          assert.equal(response.body.status, 500);
+          assert.equal(response.body.errors[0].message, 'Test Error');
           done();
         });
       });
@@ -141,4 +142,32 @@ describe('Policies', function() {
     });
   });
 
+  describe('policies for actions named with capital letters', function() {
+
+    before(function() {
+      var policy = {
+        '*' : false,
+        'test': {
+          '*': false,
+          'CapitalLetters': true
+        }
+      };
+
+      var config = "module.exports.policies = " + JSON.stringify(policy);
+      fs.writeFileSync(path.resolve('../', appName, 'config/policies.js'), config);
+    });
+
+    describe('a get request to /:controller', function() {
+
+      it('should return a string', function(done) {
+
+        httpHelper.testRoute('get', {url: 'test/CapitalLetters', json: true}, function(err, response) {
+          if (err) done(err);
+
+          assert.equal(response.body, "CapitalLetters");
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixed: Bug in policy mapping for actions with capital letters.
Added: New test to verify the above.
Fixed: httpHelper not properly detecting super startup.
Fixed: Two tests in integration/policies.test.js not properly verifying error responses.
Added: integration/policies.test.js line to mocha.opts to actually run its tests now that they work.

General note: mocha.opts only runs waterline tests. Partial fix here now that policies test properly.
