### PR TITLE
Check that socket object exists before calling subscribe

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -61,7 +61,9 @@ module.exports = function(sails) {
 					socket.join( my.room(id) );
 				});
 
-				this.subscribe(socket, id);
+				if (socket) {
+					this.subscribe(socket, id);
+				}
 			},
 
 


### PR DESCRIPTION
This fixes #724, which was throwing an exception if publishCreate was called without a socket toOmit. It keeps the intended fix of #628 while removing the unintended side-effects of removing that check completely.

Sorry for the second pull request, I completely derped cause I am unused to creating pull requests from the frontend so I was merging into master.

Fixes #724
Fixes #626
