### PR TITLE
pubsub introduce() should not call this.subscribe() when socket is null.

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -58,7 +58,9 @@ module.exports = function(sails) {
 					socket.join( my.room(id) );
 				});
 
-				this.subscribe(socket, id);
+				if( socket ) {
+					this.subscribe(socket, id);
+				}
 			},
 
 


### PR DESCRIPTION
Hello!

This fix a bug when publishCreate(id, null); is called from backend with no client socket.

J.
