### PR TITLE
don't allow an ID of `find` in the shortcut blueprints

### DIFF
--- a/lib/hooks/controllers/helpers/id.js
+++ b/lib/hooks/controllers/helpers/id.js
@@ -18,7 +18,19 @@ module.exports = function (sails) {
 	 *		Otherwise, `id` is valid and probably intentional
 	 */
 	return function validId (id, controllerId, actionId) {
-		
+
+		// The other CRUD methods are special reserved words-- in which case we always pass
+		// As long as the CRUD 'shortcut' blueprints are enabled, you cannot search for models
+		// with an id of 'find', 'update', 'create', or 'destroy'
+		var routeConf = sails.config.controllers.blueprints;
+		if (	sails.config.controllers.blueprints.shortcuts && (
+				id === 'find'   ||
+				id === 'update' ||
+				id === 'create' ||
+				id === 'destroy' )) {
+			return false;
+		}
+
 		// If expectIntegerId check is disabled, `id` is always ok
 		if ( !sails.config.controllers.blueprints.expectIntegerId ) {
 			return id;
@@ -27,17 +39,6 @@ module.exports = function (sails) {
 		// Ensure that id is numeric (unless this check is disabled)
 		var castId = +id;
 		if (id && util.isNaN(castId)) {
-
-			// The other CRUD methods are special reserved words-- in which case we always pass
-			// As long as the CRUD 'shortcut' blueprints are enabled, you cannot search for models
-			// with an id of 'update', 'create', or 'destroy'
-			var routeConf = sails.config.controllers.blueprints;
-			if (	sails.config.controllers.blueprints.shortcuts && (
-					id === 'update' || 
-					id === 'create' || 
-					id === 'destroy' )) {
-				return false;
-			}
 
 			// If it's not, move on to next middleware
 			// but emit a console warning explaining the situation


### PR DESCRIPTION
fixes an error where the shortcut method `/:model/find` was matching an id param of `find`
