### PR TITLE
NEEDS_REBASE_FOR_V0.10: allow for custom servers

### DIFF
--- a/lib/express/index.js
+++ b/lib/express/index.js
@@ -31,19 +31,26 @@ module.exports = function (sails) {
 		// Create express server
 		var app = sails.express.app = express();
 
-		// (required by Express 3.x)
-		var usingSSL = ( ( sails.config.serverOptions && sails.config.serverOptions.key && sails.config.serverOptions.cert ) ||
-					( sails.config.express && sails.config.express.serverOptions && sails.config.express.serverOptions.key && sails.config.express.serverOptions.cert ));
-		
-		// Get the appropriate server creation method for the protocol
-		var createServer = usingSSL ? require('https').createServer : require('http').createServer;
+    // Use custom server if it was defned
+    // Otherwise create a new server
+    if(typeof sails.config.server === "object") {
+      sails.express.server = sails.config.server;
+      sails.express.server.on("request", sails.express.app);
+    } else {
+  		// (required by Express 3.x)
+  		var usingSSL = ( ( sails.config.serverOptions && sails.config.serverOptions.key && sails.config.serverOptions.cert ) ||
+  					( sails.config.express && sails.config.express.serverOptions && sails.config.express.serverOptions.key && sails.config.express.serverOptions.cert ));
 
-		// Use serverOptions if they were specified
-		// Manually create http server using Express app instance
-		if (sails.config.express.serverOptions) {
-			sails.express.server = createServer(sails.config.express.serverOptions, sails.express.app);
-		}
-		else sails.express.server = createServer(sails.express.app);
+  		// Get the appropriate server creation method for the protocol
+  		var createServer = usingSSL ? require('https').createServer : require('http').createServer;
+
+  		// Use serverOptions if they were specified
+  		// Manually create http server using Express app instance
+  		if (sails.config.express.serverOptions) {
+  			sails.express.server = createServer(sails.config.express.serverOptions, sails.express.app);
+  		}
+  		else sails.express.server = createServer(sails.express.app);
+    }
 
 		// Set up location of server-side views and their engine
 		sails.express.app.set('views', sails.config.paths.views);
@@ -66,7 +73,7 @@ module.exports = function (sails) {
 		app.engine(engine, engineModule.__express);
 		sails.express.app.set('view engine', engine);
 
-		
+
 
 		// Install Express middleware
 		/////////////////////////////////////////////////////////////////
@@ -93,11 +100,11 @@ module.exports = function (sails) {
 			});
 			app.routes[method] = newRoutes;
 
-		});		
+		});
 
 		// When Sails is ready, start the express server
 		sails.on('ready', startServer);
-		
+
 
 		// Use the specified cookieParser
 		var cookieParser = sails.config.express.cookieParser;
@@ -116,8 +123,8 @@ module.exports = function (sails) {
 		if (bodyParserEnabled) {
 			app.use(bodyParser);
 
-			app.use(function handleBodyParserError (err, req, res, next) {				
-				
+			app.use(function handleBodyParserError (err, req, res, next) {
+
 				// Add key middleware
 				if (sails.config.hooks.request) {
 					sails._mixinLocals(req,res);
@@ -133,7 +140,7 @@ module.exports = function (sails) {
 
 				// Since an error occurred with the body parser,
 				// we need to pick up the middleware necessary
-				// to serve the error route which we would have 
+				// to serve the error route which we would have
 				// gotten in the router and keep going
 				next('Unable to parse HTTP body :: ' + util.inspect(err));
 			});
@@ -147,10 +154,10 @@ module.exports = function (sails) {
 
 		// Use CSRF middleware if enabled
 		if(sails.config.csrf){
-			
+
 			// Require CSRF token for non-GET requests
 			app.use(express.csrf());
-			
+
 			// Pass csrf token to templates via locals
 			app.use(function(req, res, next){
 				res.locals._csrf = req.session._csrf;


### PR DESCRIPTION
Allows users to optionally define their own custom server in their configuration.

``` js
// config/local.js
module.exports = {
  server: require("spdy").createServer(require("./spdy-options.json"))
};
```

Closes #737. Relates to #80.
