### PR TITLE
Fix i18n

### DIFF
--- a/lib/hooks/i18n/index.js
+++ b/lib/hooks/i18n/index.js
@@ -23,11 +23,7 @@ module.exports = function (sails) {
         '/*': function (req, res, next) {
 
           i18n.init(req, res, function() {
-
-            res.locals.i18n = res.i18n = function(phrase) {
-              return i18n.__(phrase);
-            };
-
+            res.locals.i18n = res.i18n = res.__;
             next();
           });
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "connect-mongo": "0.3.2",
     "async": "0.2.9",
     "winston": "0.7.1",
-    "i18n": "0.3.5",
+    "i18n": "0.4.1",
     "optimist": "0.3.4",
     "fs-extra": "0.5.0",
     "lodash": "1.2.1",


### PR DESCRIPTION
Right now **each request alters the global i18n locale**. If you send accept-language headers with one request, all subsequent requests will respond with that language until a different accept-language request is sent (completely unrelated to sessions). The `defaultLocale` config is also not supported by i18n `0.3.5` at all.

This PR upgrades i18n to 0.4.1 which includes `defaultLocale` support, better response method generation and many bugfixes.

Fixes #783 
