### PR TITLE
SocketNamespace.post doesn't fire callback function

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -182,6 +182,13 @@ module.exports = function(sails) {
 					);
 				}
 
+				// Since we just added a new model, we need to subscribe
+				// all users currently in the class room to its updates
+        // 
+        // We should do this before model is been published
+        // otherwise clients wouldn't get this update
+				this.introduce(values.id, socket);
+
 				// Broadcast success message
 				this.publish(null, {
 
@@ -191,10 +198,6 @@ module.exports = function(sails) {
 					id	: values.id
 
 				}, socket);
-
-				// Since we just added a new model, we need to subscribe
-				// all users currently in the class room to its updates
-				this.introduce(values.id, socket);
 
 			},
 


### PR DESCRIPTION
I'm trying to manage my models using websocket transport. All REST-ish SocketNamespace methods works fine but post method. It doesn't fire callback method despite new record is successfully saved so I can't finalize a transaction on client side.

My sails.js version is 0.9.3 on MacOS 10.8.4, issue confirmed in latest Chrome, FF, Opera and Safari.
#### Steps to reproduce:
1. Create a new application: `sails new test_app`
2. Create a model with REST controller: `sails g test_model`
3. Fill up model with some field: `module.exports = {
   attributes: {
     title: 'string'
   }
   };`
4. Lift sails and open the title page in browser.
5. Execute commands in browser console:

``` javascript
var log_result = function(res) {
  console.log("Result recieved");
  console.log(res)
};

window.socket.get('/test_model', log_result);
/*
Result recieved
[]
*/

window.socket.post('/test_model', {title: "123456"}, log_result);
/* no output */

window.socket.get('/test_model', log_result);
/*
Result recieved
[Object]
0: Object
createdAt: "2013-08-23T09:38:48.708Z"
id: 1
title: "123456"
updatedAt: "2013-08-23T09:38:48.708Z"
*/

window.socket.put('/test_model/1', {title: "asdasd"}, log_result);
/*
Result recieved
Object {title: "asdasd", createdAt: "2013-08-23T09:38:48.708Z", updatedAt: "2013-08-23T09:39:42.054Z", id: 1}
*/

window.socket.delete('/test_model/1', log_result);
/*
Result recieved
Object {title: "asdasd", createdAt: "2013-08-23T09:38:48.708Z", updatedAt: "2013-08-23T09:39:42.054Z", id: 1}
*/
```
#### Expected behavior:

SocketNamespace.post method to fire callback method.

I tried to add some logging alongside the sails.io.js and socket.io.js but got no success.

SocketNamespace.prototype.onPacket doesn't fire after SocketNamespace.post call.
