### PR TITLE
Development: fixed error handling

### DIFF
--- a/lib/express/index.js
+++ b/lib/express/index.js
@@ -127,7 +127,7 @@ module.exports = function (sails) {
 				return bodyParser(req, res, next);
 			});
 
-			app.use(function(err, req, res, next) {
+			app.use(function handleBodyParserError(err, req, res, next) {
 				console.log(err);
 				// Add key middleware
 				if (sails.config.hooks.request) {


### PR DESCRIPTION
if `next('Unable to parse HTTP body :: ' + util.inspect(err));` runs twice in this function it will overwrite the error returned from `config/500.js`.  This fixed that.
