### PR TITLE
Fix/improve the SSL configuration

### DIFF
--- a/lib/configuration/build.js
+++ b/lib/configuration/build.js
@@ -56,13 +56,6 @@ module.exports = function(sails) {
 		result.controllers = deepMerge(defaults.controllers, userConfig.controllers || {});
 		result.views = util.extend(defaults.views || {}, userConfig.views || {});
 
-		// Only build serverOptions if SSL is specified
-		// Otherwise it breaks the server for some reason
-		// TODO: see if this happens in Express 3.x
-		if (userConfig.ssl || (result.express && result.express.serverOptions)) {
-			util.extend(result.express.serverOptions, userConfig.ssl || {});
-		}
-
 		// Custom layout location
 		// (if string specified, it's used as the relative path from the views folder)
 		// (if not string, but truthy, relative path from views folder defaults to ./layout.*)

--- a/lib/configuration/validate.js
+++ b/lib/configuration/validate.js
@@ -225,13 +225,17 @@ module.exports = function (sails) {
 		}
 
 		// Express serverOptions override ssl, but just for the http server
-		if (originalUserConfig.ssl && 
-			(originalUserConfig.express && originalUserConfig.express.serverOptions && (originalUserConfig.express.serverOptions.cert || originalUserConfig.express.serverOptions.key))) {
-			log.warn('You specified the ssl option, but there are also ssl options specified in express.serverOptions.'+
-						'The global ssl options will be used for the websocket server, but the serverOptions values will be used for the express HTTP server.');
-			config = _.recursive.defaults(config.express.serverOptions,config.ssl);
-		}
-
+        if (originalUserConfig.ssl) {
+            config.express = config.express || {};
+            config.express.serverOptions = config.express.serverOptions || {};
+            if (originalUserConfig.express && originalUserConfig.express.serverOptions && (originalUserConfig.express.serverOptions.cert || originalUserConfig.express.serverOptions.key)) {
+                log.warn('You specified the ssl option, but there are also ssl options specified in express.serverOptions.'+
+                         'The global ssl options will be used for the websocket server, but the serverOptions values will be used for the express HTTP server.');
+                _.merge(config.express.serverOptions, config.ssl);
+            } else {
+                _.extend(config.express.serverOptions, config.ssl);
+            }
+        }
 
 		// Return marshalled session object
 		/////////////////////////////////////////////


### PR DESCRIPTION
- Do not extend config.express.serverOptions with config.ssl before
  the config validation is done: the former is undefined by default
  (#843) and that's OK as it would fire a validation warning otherwise.
- Use _.merge instead of the undefined _.recursive.defaults to set the
  default values of config.express.serverOptions (#844). Use _.extend
  if the serverOptions wasn't defined by the user's config.
