### PR TITLE
added suport for winston adapters

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -66,7 +66,24 @@ module.exports = function(sails) {
             silent: 0
         };
 
-        // TODO: if adapter option is set, ALSO write log output to an adapter
+        // if adapter option is set, ALSO write log output to an adapter
+        if (!_.isUndefined(config.adapters)) {
+            _.each(config.adapters, function(val, transport) {
+                if (typeof val.module !== 'undefined') {
+
+                    // The winston module MUST be exported to a variable of same name
+                    var module = require(val.module)[transport];
+
+                    // Make sure it was exported correctly
+                    if (module) {
+                        transports.push(
+                            new(module)(val)
+                        );
+                    }
+              }
+          });
+        }
+
         // Instantiate winston
         var logger = new(winston.Logger)({
             transports: transports


### PR DESCRIPTION
To use add adapters to your log.js file similar to below

``` Javascript
log: {
    level: 'info',

    adapters: {
      LogstashUDP: {
        module: 'winston-logstash-udp',
        port: 8150,
        appName: 'my_cool_sails_app'
      }
    }
  }
```
