### PR TITLE
Support resource-ful REST Url mapping

### DIFF
--- a/lib/router/bind.js
+++ b/lib/router/bind.js
@@ -144,9 +144,16 @@ module.exports = function (sails) {
 			controller = sails.middleware.views[controllerId];
 		}
 
-		// If a controller was specified but it doesn't match, warn the user
-		if ( ! (controller && util.isDictionary(controller) && controller[actionId || 'index']) ) {
-
+		// If a controller and/or action was specified, 
+		// but it's not a match, warn the user
+		if ( ! ( controller && util.isDictionary(controller) )) {
+			sails.log.error(
+				controllerId,
+				':: Ignoring attempt to bind route (' + path + ') to unknown controller.'
+			);
+			return;
+		}
+		if ( actionId && !controller[actionId] ) {
 			sails.log.error(
 				controllerId + '.' + (actionId || 'index'),
 				':: Ignoring attempt to bind route (' + path + ') to unknown controller.action.'
@@ -154,10 +161,12 @@ module.exports = function (sails) {
 			return;
 		}
 
-		// If specified, lookup the `action` function, otherwise lookup index
-		var subTarget = controller[actionId || 'index'];
 
-		// Make sure the controller function (+/- policies, etc.) is usable
+		// If unspecified, default actionId to 'index'
+		actionId = actionId || 'index';
+
+		// Bind the action subtarget
+		var subTarget = controller[actionId];
 		if (util.isArray(subTarget)) {
 			util.each(subTarget, function bindEachMiddlewareInSubTarget (fn) {
 				_bind(path, controllerHandler(fn), verb, target);
@@ -167,6 +176,22 @@ module.exports = function (sails) {
 		
 		// Bind a controller function to the destination route
 		_bind(path, controllerHandler(subTarget), verb, target);
+		
+
+
+		// If actionId not specified, inject middleware which will set req.target
+		// to allow the action, shortcut, and crud blueprints to take effect
+		// (if they are enabled)
+			
+		// TODO: Bind all blueprints to the destination route
+
+		// TODO: Actually, move this logic to the controller hook-- 
+		// which should listen to the 'route:typeUnknown' event and handle 
+		// these sorts of routes as prefixed blueprint routes
+		// e.g. '/bar': { controller: 'FooController' }
+		// binds FooController to both /bar and /foo, with all relevant blueprints attached, 
+		// e.g. `get /foo`, `post /foo`, `/foo/:action/:id?`, `/foo/create`, `/foo/update/:id?`, 
+		// and all the rest!
 
 
 		// Wrap up the controller middleware to supply access to


### PR DESCRIPTION
Related to the issue I submitted (#877)

Something like the following will also help if put along the custom routes section.
For REST resources based routes just like that of rails,
do the following:

``` js
  "/user": {
    resource : "UserController"
  }
```

which is equivalent to

``` js
  "get /user"          : "UserController.index",
  "get /user/add"      : "UserController.add",
  "get /user/:id"      : "UserController.show",
  "get /user/:id/edit" : "UserController.edit",
  "post /user"         : "UserController.create",
  "put /user/:id"      : "UserController.update",
  "delete /user/:id"   : "UserController.destroy"
```
