### PR TITLE
Use child_process.fork instead of exec when loading grunt.

### DIFF
--- a/lib/grunt/index.js
+++ b/lib/grunt/index.js
@@ -12,21 +12,29 @@ module.exports = function (sails) {
 		}
 
 		// Build command to run Gruntfile
-		var cmd = 'node ' + pathToSails + '/node_modules/grunt-cli/bin/grunt ' +
-					taskName +
-					' --gdsrc=' + pathToSails + '/node_modules' +
-					' --environment=' + environment +
-					' --baseurl=' + baseurl +
-					' --signalpath=' + signalpath;
+		var cmd = pathToSails + '/node_modules/grunt-cli/bin/grunt',
+			args = [
+				taskName,
+				'--gdsrc=' + pathToSails + '/node_modules',
+				'--environment=' + environment,
+				'--baseurl=' + baseurl,
+				'--signalpath=' + signalpath
+			],
+			options = {
+				silent: true,
+				stdio: 'pipe'
+			};
 
 		// Spawn grunt process
-		var child = require('child_process').exec(cmd);
+		var child = require('child_process').fork(cmd, args, options);
 
 		var errorMsg = '';
 		var stackTrace = '';
 
 		// Log output as it comes in to the appropriate log channel
 		child.stdout.on('data', function (consoleMsg) {
+
+			consoleMsg = consoleMsg.toString();
 
 			// store all the output
 			errorMsg += consoleMsg + '\n';


### PR DESCRIPTION
Possible fix for #899. Fork automatically uses the same version of node that's running the current process rather than looking in `$PATH`.
