### PR TITLE
Got rid of mustache style interpolate regex for JST templateSettings

### DIFF
--- a/bin/boilerplates/Gruntfile.js
+++ b/bin/boilerplates/Gruntfile.js
@@ -168,11 +168,6 @@ module.exports = function (grunt) {
 
     jst: {
       dev: {
-        options: {
-          templateSettings: {
-            interpolate: /\{\{(.+?)\}\}/g
-          }
-        },
         files: {
           '.tmp/public/jst.js': templateFilesToInject
         }


### PR DESCRIPTION
It was confusing to have the JST templates to be interpolated with mustache style notation while the escaping and evaluating were done with ejs notation. We remove the template settings so that all three use ejs style notation.
