### PR TITLE
Travis not running any tests - Update package.json to ensure test files are run

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "sails": "./bin/sails.js"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha test/**/*.js"
   },
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
The package.json scripts test section did not include a test file
path and file mask. This means that Travis was not previously
running tests.

This may break the CI build but it will mean tests are being run on
Travis.
