### PR TITLE
Use `io` from the local namespace

### DIFF
--- a/bin/boilerplates/assets/js/sails.io.js
+++ b/bin/boilerplates/assets/js/sails.io.js
@@ -123,7 +123,7 @@
     }
 
     // Build to request
-    var json = window.io.JSON.stringify({
+    var json = io.JSON.stringify({
       url: url,
       data: data
     });
@@ -136,7 +136,7 @@
 
       if (result && typeof result === 'string') {
         try {
-          parsedResult = window.io.JSON.parse(result);
+          parsedResult = io.JSON.parse(result);
         } catch (e) {
           if (typeof console !== 'undefined') {
             console.warn("Could not parse:", result, e);


### PR DESCRIPTION
If `socket.io` is wrapped, we should use the local `io`.
