### PR TITLE
sails teardown should handle SIGUSR2 kill signal

### DIFF
--- a/lib/app/teardown.js
+++ b/lib/app/teardown.js
@@ -10,7 +10,7 @@ module.exports = function (sails) {
 
 
 	return function bindTeardownEvents () {
-		process.on('SIGUSR2', function() {
+		process.once('SIGUSR2', function() {
 			sails.lower(function() {
 				process.kill(process.pid, 'SIGUSR2'); 
 			});


### PR DESCRIPTION
runnig sails in development mode using [nodemon](https://github.com/remy/nodemon) causes one new grunt instance on every sails lift while the old grunt instance is still running and watching... 

nodemon sends a **SIGUSR2** kill signal to an app when it sees a file update.

this commit handles this kill signal and lowers sail gracefully.
