### PR TITLE
adjust the postition of customMiddleware

### DIFF
--- a/lib/express/index.js
+++ b/lib/express/index.js
@@ -115,6 +115,12 @@ module.exports = function (sails) {
 		// Connect session to express
 		app.use(express.session(sails.config.session));
 
+		// Allow full REST simulation for clients which don't support it natively
+		// (by using _method parameter)
+		if (sails.config.express.methodOverride) {
+			app.use(sails.config.express.methodOverride());
+		}
+
 	  
 		// Use body parser, if enabled
 		if (bodyParserEnabled) {
@@ -174,13 +180,6 @@ module.exports = function (sails) {
 
 		var limitDefault = sails.config.fileUpload.maxMB;
 		// TODO: add file upload / bodyParser config
-
-
-		// Allow full REST simulation for clients which don't support it natively
-		// (by using _method parameter)
-		if (sails.config.express.methodOverride) {
-			app.use(sails.config.express.methodOverride());
-		}
 
 		// Allow usage of custom express middleware
 		// Must be before the router


### PR DESCRIPTION
i want to write some code about xml raw data,but bodyParser will discard my xml raw request, i have to put customMiddleware before bodyParser, i think i want to have more power to controller of my middleware as a developer 
