### PR TITLE
Don't set CORS headers if the Origin header is missing from the request

### DIFF
--- a/lib/hooks/cors/index.js
+++ b/lib/hooks/cors/index.js
@@ -79,7 +79,7 @@ module.exports = function(sails) {
 		}
 		return function(req, res, next) {
 			// If we can set headers (i.e. it's not a socket request), do so.
-			if (res.setHeader) {
+			if (req.headers.origin && res.setHeader) {
 
 				// Get the allowed origins
 				var origins = (routeCorsConfig.origin || sails.config.cors.origin).split(',');


### PR DESCRIPTION
Current behaviour is broken:

``` bash
$ curl -i http://localhost:1337/test
```

``` http
HTTP/1.1 200 OK
X-Powered-By: Sails <sailsjs.org>
Access-Control-Allow-Origin: undefined
Access-Control-Allow-Credentials: true
```

After this change the CORS headers are only added if Origin is present in the request. This is similar to e.g. `rack-cors`.
