### PR TITLE
added 'sails c' as a shortcut for 'sails console'

### DIFF
--- a/bin/sails.js
+++ b/bin/sails.js
@@ -75,7 +75,7 @@ require('../lib/configuration')(sails).load(function (err) {
 
 
   // Check if console was requested, if so, launch console
-  else if (_.contains(['console'], argv._[0])) {
+  else if (_.contains(['console', 'c'], argv._[0])) {
     console.log();
     sails.log('Welcome to the Sails console (v' + sails.version + ')');
     sails.log('( to exit, type <CTRL>+<C> )');


### PR DESCRIPTION
"sails c" alias for "sails console"

Brings in a familiar shortcut that I liked for rails console.
