### PR TITLE
Add res.unauthorized() mixin

### DIFF
--- a/bin/boilerplates/config/401.js
+++ b/bin/boilerplates/config/401.js
@@ -1,0 +1,52 @@
+/**
+ * Default 401 (Unauthorized) middleware
+ *
+ * This middleware can be invoked from a controller or policy:
+ * res.unauthorized( [message] )
+ *
+ *
+ * @param {String|Object|Array} message
+ *      optional message to inject into view locals or JSON response
+ * 
+ */
+
+module.exports[401] = function unauthorized(message, req, res) {
+
+  /*
+   * NOTE: This function is Sails middleware-- that means that not only do `req` and `res`
+   * work just like their Express equivalents to handle HTTP requests, they also simulate
+   * the same interface for receiving socket messages.
+   */
+
+  var viewFilePath = '401';
+  var statusCode = 401;
+
+  var result = {
+    status: statusCode
+  };
+
+  // Optional message
+  if (message) {
+    result.message = message;
+  }
+
+  // If the user-agent wants a JSON response, send json
+  if (req.wantsJSON) {
+    return res.json(result, result.status);
+  }
+
+  // Set status code and view locals
+  res.status(result.status);
+  for (var key in result) {
+    res.locals[key] = result[key];
+  }
+  // And render view
+  res.render(viewFilePath, result, function (err) {
+    // If the view doesn't exist, or an error occured, send json
+    if (err) { return res.json(result, result.status); }
+    
+    // Otherwise, serve the `views/401.*` page
+    res.render(viewFilePath);
+  });
+
+};

--- a/bin/boilerplates/views/ejs/401.ejs
+++ b/bin/boilerplates/views/ejs/401.ejs
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<!-- 
+                                               
+                                               
+       444444444       000000000        1111111
+      4::::::::4     00:::::::::00     1::::::1
+     4:::::::::4   00:::::::::::::00  1:::::::1
+    4::::44::::4  0:::::::000:::::::01::::::::1
+   4::::4 4::::4  0::::::0   0::::::0   1:::::1
+  4::::4  4::::4  0:::::0     0:::::0   1:::::1
+ 4::::4   4::::4  0:::::0     0:::::0   1:::::1
+4::::444444::::4440:::::0 000 0:::::0   1:::::1
+4::::::::::::::::40:::::0 000 0:::::0   1:::::1
+4444444444:::::4440:::::0     0:::::0   1:::::1
+          4::::4  0:::::0     0:::::0   1:::::1
+          4::::4  0::::::0   0::::::0   1:::::1
+          4::::4  0:::::::000:::::::0   1:::::1
+        44::::::44 00:::::::::::::00  11:::::::11
+        4::::::::4   00:::::::::00    11:::::::11
+        4444444444     000000000      11111111111
+                                          
+
+                                                        
+  This is the default "401: Unauthorized" page.
+  User agents that don't "Accept" HTML will see a JSON version instead.
+  You can customize the control logic for your needs in `config/401.js`
+
+  You can trigger this response from one of your controllers or policies with:
+  `return res.unauthorized( msg );`
+  (where `msg` is an optional error message to include in the response)
+
+
+
+
+-->
+<html>
+  <head>
+    <title>Unauthorized</title>
+    <link href='http://sailsjs.org/styles/fonts.css' rel='stylesheet'/>
+    <style>
+      /* Styles included inline since you'll probably be deleting or replacing this page anyway */
+      html,body{text-align:left;font-size:1em}html,body,img,form,textarea,input,fieldset,div,p,div,ul,li,ol,dl,dt,dd,h1,h2,h3,h4,h5,h6,pre,code{margin:0;padding:0}ul,li{list-style:none}img{display:block}a img{border:0}a{text-decoration:none;font-weight:normal;font-family:inherit}*:active,*:focus{outline:0;-moz-outline-style:none}h1,h2,h3,h4,h5,h6,h7{font-weight:normal;font-size:1em}.clearfix:after{clear:both;content:".";display:block;font-size:0;height:0;line-height:0;visibility:hidden}.page .ocean{background:url('http://sailsjs.com/images/waves.png') #0c8da0 no-repeat center 0;height:315px}.page .ocean img{margin-right:auto;margin-left:auto}.page .waves{display:block;padding-top:25px;margin-right:auto;margin-left:auto}.page .main{display:block;margin-top:90px}.page .logo{width:150px;margin-top:3.5em;margin-left:auto;margin-right:auto}.page .fishy{display:block;padding-top:100px}.page .help{padding-top:2em}.page h1{font-family:"Open Sans","Myriad Pro",Arial,sans-serif;font-weight:bold;font-size:1.7em;color:#001c20;text-align:center}.page h2{font-family:"Open Sans","Myriad Pro",Arial,sans-serif;font-weight:300;font-size:1.5em;color:#001c20;text-align:center}.page p{font-family:"Open Sans","Myriad Pro",Arial,sans-serif;font-size:1.25em;color:#001c20;text-align:center}.page a{color:#118798}.page a:hover{color:#b1eef7}
+    </style>
+  </head>
+  <body>
+
+    <div class="page">
+      <div class="ocean">
+        <img class="fishy" src="http://sailsjs.com/images/image_devInTub.png">
+      </div>
+
+      <div class="main">
+        <h1>
+          Unauthorized
+        </h1>
+        <h2> 
+          <% if (typeof message !== 'undefined') { %>
+          <%= message %>
+          <% } else { %>
+          You need to be authenticated to see the page you're trying to reach.
+          <% } %>
+        </h2>
+        <p class="help">
+          <a href="http://en.wikipedia.org/wiki/HTTP_401">Why</a> might this be happening?
+        </p>
+      </div>
+        
+      <div class="logo">
+        <a href="http://sailsjs.org">
+          <img src="http://sailsjs.org/images/logo.png">
+        </a>
+      </div>
+    </div>
+
+  </body>
+</html>

--- a/bin/boilerplates/views/jade/401.jade
+++ b/bin/boilerplates/views/jade/401.jade
@@ -1,0 +1,23 @@
+!!! 5
+html
+  head
+    title Unauthorized
+    link(href='http://sailsjs.org/styles/fonts.css', rel='stylesheet')
+    style
+      /* Styles included inline since you'll probably be deleting or replacing this page anyway */
+      html,body{text-align:left;font-size:1em}html,body,img,form,textarea,input,fieldset,div,p,div,ul,li,ol,dl,dt,dd,h1,h2,h3,h4,h5,h6,pre,code{margin:0;padding:0}ul,li{list-style:none}img{display:block}a img{border:0}a{text-decoration:none;font-weight:normal;font-family:inherit}*:active,*:focus{outline:0;-moz-outline-style:none}h1,h2,h3,h4,h5,h6,h7{font-weight:normal;font-size:1em}.clearfix:after{clear:both;content:".";display:block;font-size:0;height:0;line-height:0;visibility:hidden}.page .ocean{background:url('http://sailsjs.com/images/waves.png') #0c8da0 no-repeat center 0;height:315px}.page .ocean img{margin-right:auto;margin-left:auto}.page .waves{display:block;padding-top:25px;margin-right:auto;margin-left:auto}.page .main{display:block;margin-top:90px}.page .logo{width:150px;margin-top:3.5em;margin-left:auto;margin-right:auto}.page .fishy{display:block;padding-top:100px}.page .help{padding-top:2em}.page h1{font-family:"Open Sans","Myriad Pro",Arial,sans-serif;font-weight:bold;font-size:1.7em;color:#001c20;text-align:center}.page h2{font-family:"Open Sans","Myriad Pro",Arial,sans-serif;font-weight:300;font-size:1.5em;color:#001c20;text-align:center}.page p{font-family:"Open Sans","Myriad Pro",Arial,sans-serif;font-size:1.25em;color:#001c20;text-align:center}.page a{color:#118798}.page a:hover{color:#b1eef7}
+  body
+    .page
+      .ocean
+        img.fishy(src='http://sailsjs.com/images/image_devInTub.png')
+      .main
+        h1
+          | Unauthorized
+        h2
+          | You need to be authenticated to see the page you're trying to reach.
+        p.help
+          a(href='http://en.wikipedia.org/wiki/HTTP_401') Why
+          | might this be happening?
+      .logo
+        a(href='http://sailsjs.org')
+          img(src='http://sailsjs.org/images/logo.png')

--- a/lib/hooks/request/index.js
+++ b/lib/hooks/request/index.js
@@ -169,8 +169,28 @@ module.exports = function(sails) {
 
 
 	/**
+	 * res.unauthorized()
+	 * (i.e. 401: Unauthorized)
+	 *
+	 * Respond as defined in `config/401.js`
+	 *
+	 * @param {Request} req
+	 * @param {Response} res
+	 * @api private
+	 */
+
+	function _mixinResUnauthorized(req, res) {
+		res.unauthorized = function respond401(err) {
+			sails.config[401](err, req, res, function fallback(e) {
+				res.send(e || err || undefined, 401);
+			});
+		};
+	}
+
+
+	/**
 	 * res.forbidden()
-	 * (i.e. 403: Forbidden or 401: Unauthorized)
+	 * (i.e. 403: Forbidden)
 	 *
 	 * Respond as defined in `config/403.js`
 	 *
@@ -189,7 +209,7 @@ module.exports = function(sails) {
 
 
 	/**
-	 * res.invalid()
+	 * res.badRequest()
 	 * (i.e. 400: Bad Request)
 	 *
 	 * Respond as defined in `config/400.js`


### PR DESCRIPTION
Since HTTP Status Code 401 Unauthorized is actually quite different from 403 Forbidden, I suggest there should be a separate mixin for that. 

401 indicates that authentication is needed, while 403 indicates that further authentication has no effect - the resource will still be forbidden.

This PR adds the mixin and related boilerplate views / config.

PS. It also fixes the wrong comment title for res.badRequest().
