### PR TITLE
Allow setting hook priority

### DIFF
--- a/lib/app/load.js
+++ b/lib/app/load.js
@@ -164,6 +164,8 @@ module.exports = function (sails) {
 			hooks[id] = new Hook(def);
 		});
 
+		// Sort hooks by priority
+		hooks = util.sortBy(hooks, function (hook) { return hook.priority });
 
 		// Call `load` on each hook
 		async.auto({

--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -85,6 +85,9 @@ module.exports = function (sails) {
 			// Default hook config
 			def.config = def.config || {};
 
+			// Default hook priority
+			def.priority = def.priority || 10;
+
 			// list of environments to run in, if empty defaults to all
 			def.config.envs = def.config.envs || [];
 


### PR DESCRIPTION
This PR allows setting a priority number for a hook. Hooks with higher priority will be loaded before others. Higher priority = lower number. Lower priority = higher number.

The default priority is 10. This should allow enough flexibility to load user-defined hooks before built-in hooks.

An example use-case is where a user wants run some middleware before the built-in CORS or CSRF middleware, potentially to do some kind of pre-filtering or whitelisting, etc.
