### PR TITLE
Allow bypassing CSRF protection when res.bypassCsrf is true.

### DIFF
--- a/lib/hooks/csrf/index.js
+++ b/lib/hooks/csrf/index.js
@@ -20,7 +20,7 @@ module.exports = function(sails) {
 			before: {
 				'/*': function(req, res, next) {
 
-					if (sails.config.csrf && (!req.headers.origin || util.isSameOrigin(req))) {
+					if (sails.config.csrf && !res.bypassCsrf && (!req.headers.origin || util.isSameOrigin(req))) {
 						var connect = require('express/node_modules/connect');
 
 						return connect.csrf()(req, res, function (err) {


### PR DESCRIPTION
Motivation: sometimes it is necessary to disable CSRF on some routes or based on some other criteria - for example, whether the requesting client/browser actually supports sessions.

My use-case is that I need to bypass CSRF whenever someone has authenticated with an API key using HTTP Basic Auth and is connecting using `cURL` or similar means where sessions do not exist or are cumbersome to setup for an API consumer.

Note: it is true that if my API consumer were to connect using a regular browser, it would make the app possibly vulnerable to CSRF attacks (because HTTP Auth headers are cached by browsers). However, I believe it is a concern that the app developer has to take care of by explaining the implications to API consumers. Maybe it is also worth noting that I have looked at several SaaS APIs that use HTTP Basic Auth for authentication and do not have any kind of CSRF protection in place.
