### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-contrib-copy": "0.4.1",
     "grunt-contrib-clean": "0.4.1",
     "grunt-contrib-concat": "0.3.0",
-    "grunt-sails-linker": "git://github.com/Zolmeister/grunt-sails-linker.git",
+    "grunt-sails-linker": "https://github.com/Zolmeister/grunt-sails-linker.git",
     "grunt-contrib-jst": "0.5.0",
     "grunt-contrib-watch": "0.4.4",
     "grunt-contrib-uglify": "0.2.2",


### PR DESCRIPTION
Behind some enterprise firewalls, git and its 9418 port is not available. Replaced git by https.
