### PR TITLE
Allow the lift timeout to be configurable.

### DIFF
--- a/lib/express/start.js
+++ b/lib/express/start.js
@@ -11,6 +11,7 @@ module.exports = function (sails) {
 
 		// Used to warn about possible issues if starting the server is taking a very long time
 		var liftAbortTimer;
+        var liftTimeout = sails.config.liftTimeout || 500;
 
 		async.auto({
 
@@ -33,7 +34,7 @@ module.exports = function (sails) {
 					sails.log.error('Perhaps something else is already running on port ' + sails.config.port + 
 									(sails.explicitHost ? (' with hostname ' + sails.explicitHost) : '') + 
 									'?');
-				}, 500);
+				}, liftTimeout);
 			},
 
 			verify: ['start', function (cb) {


### PR DESCRIPTION
This addresses issue #1070. 

A test would require parsing log output for presence of the error message, so maybe you will accept this as simple refactoring. It works in my environment. 
