### PR TITLE
Support seperate logging levels for console and file.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -31,15 +31,24 @@ module.exports = function(sails) {
             maxFiles: 10,
             json: false,
             colorize: true,
-            level: 'info'
+            level: 'info',
+            consoleLevel: 'undefined',
+            fileLevel: 'undefined'
         });
+
+        if (config.consoleLevel === 'undefined') {
+            config.consoleLevel = config.level;
+        }
+        if (config.fileLevel === 'undefined') {
+            config.fileLevel = config.level;
+        }
 
         var winston = require('winston');
 
         // Available transports
         var transports = [
             new(winston.transports.Console)({
-                level: 'debug',
+                level: config.consoleLevel,
                 colorize: config.colorize
             })
         ];
@@ -51,19 +60,43 @@ module.exports = function(sails) {
                 filename: config.filePath,
                 maxsize: config.maxSize,
                 maxFiles: config.maxFiles,
-                level: 'verbose',
+                level: config.fileLevel,
                 json: config.json,
-                colorize: config.colorize
+                stripColors: true,
+                colorize: false
             }));
         }
 
         var logLevels = {
-            verbose: 5,
-            info: 4,
+            silly: 0,
+            verbose: 1,
+            info: 2,
+            notice: 2,
             debug: 3,
-            warn: 2,
-            error: 1,
-            silent: 0
+            alert: 4,
+            warn: 4,
+            warning: 4,
+            error: 5,
+            crit: 6,
+            emerg: 6,
+            fail: 6,
+            silent: 7
+        };
+
+        var logColors = {
+            silly: 'cyan',
+            verbose: 'cyan',
+            info: 'green',
+            notice: 'green',
+            debug: 'blue',
+            alert: 'yellow',
+            warn: 'yellow',
+            warning: 'yellow',
+            error: 'red',
+            crit: 'red',
+            emerg: 'red',
+            fail: 'red',
+            silent: 'white'
         };
 
         // if adapter option is set, ALSO write log output to an adapter
@@ -86,6 +119,8 @@ module.exports = function(sails) {
 
         // Instantiate winston
         var logger = new(winston.Logger)({
+            levels: logLevels,
+            colors: logColors,
             transports: transports
         });
 
@@ -97,6 +132,7 @@ module.exports = function(sails) {
         CaptainsLog.info = log('info');
         CaptainsLog.warn = log('warn');
         CaptainsLog.error = log('error');
+        CaptainsLog.fail = log('fail');
 
         // ASCII art and easter eggs
         CaptainsLog.ship = drawShip(CaptainsLog);
@@ -129,9 +165,7 @@ module.exports = function(sails) {
                     str.push(arg);
                 });
 
-                if (logLevels[level] <= logLevels[self.config.level]) {
-                    logger[level](str.join(' '));
-                }
+                logger.log(level, str.join(' '));
             };
         }
     }


### PR DESCRIPTION
The current logger.js doesn't support separate logging levels for the console and for a log file. This patch allows the config to specify a single log level or separate log levels for the console and for the log file. In order to accomplish that, we have to allow Winston to handle choosing whether to log, which requires providing the log levels to Winston during configuration. I added the "common" log levels that other packages use to easily support logging from them and added a "fail" level as well.

It's not in this patch but I HIGHLY suggest flipping the priority level of Info and Debug. It makes no sense for Debug to be higher in priority then Debug.
