### PR TITLE
added variable references to assets directory

### DIFF
--- a/bin/boilerplates/Gruntfile.js
+++ b/bin/boilerplates/Gruntfile.js
@@ -16,7 +16,7 @@
 
 module.exports = function (grunt) {
 
-
+  var assetsDir = '<%= assetsDir %>';
 
   /**
    * CSS files to inject in order
@@ -117,7 +117,7 @@ module.exports = function (grunt) {
   
   
   templateFilesToInject = templateFilesToInject.map(function (path) {
-    return 'assets/' + path;
+    return assetsDir + '/' + path;
   });
 
 
@@ -143,7 +143,7 @@ module.exports = function (grunt) {
         files: [
           {
           expand: true,
-          cwd: './assets',
+          cwd: './' + assetsDir,
           src: ['**/*.!(coffee)'],
           dest: '.tmp/public'
         }
@@ -187,13 +187,13 @@ module.exports = function (grunt) {
         files: [
           {
           expand: true,
-          cwd: 'assets/styles/',
+          cwd: assetsDir + '/styles/',
           src: ['*.less'],
           dest: '.tmp/public/styles/',
           ext: '.css'
         }, {
           expand: true,
-          cwd: 'assets/linker/styles/',
+          cwd: assetsDir + '/linker/styles/',
           src: ['*.less'],
           dest: '.tmp/public/linker/styles/',
           ext: '.css'
@@ -210,13 +210,13 @@ module.exports = function (grunt) {
         files: [
           {
             expand: true,
-            cwd: 'assets/js/',
+            cwd: assetsDir + '/js/',
             src: ['**/*.coffee'],
             dest: '.tmp/public/js/',
             ext: '.js'
           }, {
             expand: true,
-            cwd: 'assets/linker/js/',
+            cwd: assetsDir + '/linker/js/',
             src: ['**/*.coffee'],
             dest: '.tmp/public/linker/js/',
             ext: '.js'
@@ -404,7 +404,7 @@ module.exports = function (grunt) {
       assets: {
 
         // Assets to watch:
-        files: ['assets/**/*'],
+        files: [assetsDir + '/**/*'],
 
         // When assets are changed:
         tasks: ['compileAssets', 'linkAssets']

--- a/bin/new.js
+++ b/bin/new.js
@@ -71,9 +71,9 @@ module.exports = function(sails) {
 
 		// options.useLinker will determin the assets dir stucture for the new sails project 
 		if (options.useLinker) {
-			utils.copyBoilerplate('linkerAssets', outputPath + '/assets');
+			utils.copyBoilerplate('linkerAssets', outputPath + '/' + options.assetsDir);
 		} else {
-			utils.copyBoilerplate('assets', outputPath + '/assets');
+			utils.copyBoilerplate('assets', outputPath + '/' + options.assetsDir);
 		}
 
 		// Add these boilerplate dirs regardless
@@ -157,7 +157,8 @@ module.exports = function(sails) {
 
 		// Copy Gruntfile
 		sails.log.verbose('Generating Gruntfile...');
-		utils.generateFile('Gruntfile.js', outputPath + '/Gruntfile.js');
+		utils.generateFileFromTemplate('Gruntfile.js', outputPath + '/Gruntfile.js', 
+			{ assetsDir: options.assetsDir });
 
 		// Generate README
 		sails.log.verbose('Generating README.md...');

--- a/bin/sails.js
+++ b/bin/sails.js
@@ -246,7 +246,10 @@ require('../lib/configuration')(sails).load(function (err, config) {
 
       // Default to not using the script linker functionality, 
       // but use it if --linker option is set
-      useLinker: !!argv.linker
+      useLinker: !!argv.linker,
+
+
+      assetsDir: argv['assets-location'] || argv['assets-loc'] || 'assets'
     });
   }
 

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -54,6 +54,26 @@ module.exports = function(sails) {
 		};
 
 
+		/**
+		 * Generate a file from a template.
+		 *
+		 * @api private
+		 */
+
+		this.generateFileFromTemplate = function(boilerplatePath, newPath, data) {
+			var fullBpPath = __dirname + '/boilerplates/' + (boilerplatePath || '');
+			var file = fs.readFileSync(fullBpPath, 'utf8');
+			var newFilePath = (newPath || '');
+			this.verifyDoesntExist(newFilePath, 'A file/directory already exists at ' + newFilePath);
+
+			// Touch output file to make sure the path to it exists
+			if (fs.createFileSync(newFilePath)) {
+				sails.log.error('Could not create file, ' + newFilePath + '!');
+				process.exit(1);
+			}
+			fs.writeFileSync(newFilePath, _.template(file, data));
+		};
+
 
 		/**
 		 * Generate a directory
@@ -320,7 +340,7 @@ module.exports = function(sails) {
 		this.capitalize = function(str) {
 			return require('underscore.string').capitalize(str);
 		};
-
+		
 
 		_.bindAll(this);
 


### PR DESCRIPTION
Adds the ability to specify the location of the assets directory when generating a new sails project.  For example, the command:

``` bash
mkdir myproject && cd myproject
sails new server --assets-location '../client'
```

Generates a folder structure like this:

```
myproject
  + client
  | - images
  | - js
  | - styles
  |   favicon.ico
  |   robots.txt
  + server
  | - api
  | - config
  | - node_modules
  | - views
  |     .gitignore
  |   .Gruntfile.js
  |   .README.md
  |   app.js
  |   package.json
```

I've closed this [issue](https://github.com/balderdashy/sails/issues/1168) I opened since this pull request resolves it.
