### PR TITLE
use sails.log instead of console.log()

### DIFF
--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -154,7 +154,7 @@ function Sails () {
 			sails.log.info('Server lifted in `' + sails.config.appPath + '`');
 			sails.log.info('To see your app, visit ' + localAppURL);
 			sails.log.info('To shut down Sails, press <CTRL> + C at any time.');
-			console.log();
+			log();
             log('--------------------------------------------------------');
 			log(':: ' + new Date());
 			log();


### PR DESCRIPTION
It would be great if we could replace this `console.log()` with a `sails.log`. In my integration tests this `console.log` call messes up the output of the mocha reporter by printing new lines to the console. If its replaces with a `sails.log` I can disable these newlines along with other log output by setting the log level to `error`. Thanks.
