### PR TITLE
Separating database and model configuration

### DIFF
--- a/bin/boilerplates/config/adapters.js
+++ b/bin/boilerplates/config/adapters.js
@@ -12,12 +12,9 @@
  * http://sailsjs.org/#documentation
  */
 
+var config = require('./local.js');
+var dbConfig = require('./database.js')[config.environment];
 module.exports.adapters = {
-
-  // If you leave the adapter config unspecified 
-  // in a model definition, 'default' will be used.
-  'default': 'disk',
-
   // Persistent adapter for DEVELOPMENT ONLY
   // (data is preserved when the server shuts down)
   disk: {
@@ -29,11 +26,9 @@ module.exports.adapters = {
   myLocalMySQLDatabase: {
 
     module: 'sails-mysql',
-    host: 'YOUR_MYSQL_SERVER_HOSTNAME_OR_IP_ADDRESS',
-    user: 'YOUR_MYSQL_USER',
-    // Psst.. You can put your password in config/local.js instead
-    // so you don't inadvertently push it up if you're using version control
-    password: 'YOUR_MYSQL_PASSWORD', 
-    database: 'YOUR_MYSQL_DB'
+    host: dbConfig.host,
+    user: dbConfig.username,
+    password: dbConfig.password,
+    database: dbConfig.database
   }
 };

--- a/bin/boilerplates/config/database.js
+++ b/bin/boilerplates/config/database.js
@@ -1,0 +1,22 @@
+config = require('./local.js');
+
+module.exports = {
+  "development": {
+    "username": "root",
+    "password": null,
+    "database": "database_dev",
+    "host": "127.0.0.1"
+  },
+  "test": {
+    "username": "root",
+    "password": null,
+    "database": "database_test",
+    "host": "127.0.0.1"
+  },
+  "production": {
+    "username": "root",
+    "password": null,
+    "database": "database_production",
+    "host": "127.0.0.1"
+  }
+};

--- a/bin/boilerplates/config/model.js
+++ b/bin/boilerplates/config/model.js
@@ -1,0 +1,6 @@
+module.exports.model = {
+  // If you leave the adapter config unspecified
+  // in a model definition, 'default' will be used.
+  adapter: 'disk',
+  migrate: 'alter'
+};

--- a/test/cli/integration/new.test.js
+++ b/test/cli/integration/new.test.js
@@ -208,6 +208,8 @@ function checkGeneratedFiles(appName, templateLang) {
 		'config/adapters.js',
 		'config/bootstrap.js',
 		'config/controllers.js',
+    'config/database.js',
+    'config/model.js',
 		'config/cors.js',
 		'config/csrf.js',
 		'config/i18n.js',


### PR DESCRIPTION
-   Added config/database.js which includes database specific configuration, this is to allow separating the config to both environments and to allow external tools to easily change the password/etc(like Engineyard)
-   Added config/model.js which sets the default adapter/migration policy for the models
