### PR TITLE
Adding dynaimc session adpaters

### DIFF
--- a/lib/session/index.js
+++ b/lib/session/index.js
@@ -60,7 +60,14 @@ module.exports = function (sails) {
 
 					// Unknown session adapter
 					default:
-						return cb( new Error('Invalid session adapter :: ' + sessionConfig.adapter) );
+						// try an load the adapter, catch and throw error
+						try {
+							sessionConfig.store = new(require(sessionConfig.adapter)(require('express')))(sessionConfig);
+							break;
+						} 
+						catch {
+							return cb( new Error('Invalid session adapter :: ' + sessionConfig.adapter) );
+						}
 				}
 			}
 


### PR DESCRIPTION
Adding the ability to define a session adapter other than the 3 known
types. Will catch and throw unknown modules as invalid session adapter
error.

Have hit an issue where connect-mongo doesn't support replica sets and lets be honest after 9 months of inactivity, it probably wont. This change allows users to define a customer session store to use while maintaining errors that are thrown etc.
