### PR TITLE
Separate logging settings for console and file

### DIFF
--- a/lib/hooks/logger/captains.js
+++ b/lib/hooks/logger/captains.js
@@ -18,13 +18,22 @@ module.exports = function CaptainsLog ( config ) {
 		maxSize: 10000000,
 		maxFiles: 10,
 		json: false,
-		colorize: true
+		colorize: true,
+		consoleLevel: 'undefined',
+		fileLevel: 'undefined'
 	}, config || {});
+
+	if (config.consoleLevel === 'undefined') {
+	    config.consoleLevel = config.level;
+	}
+	if (config.fileLevel === 'undefined') {
+	    config.fileLevel = config.level;
+	}
 
 	// Available transports
 	var transports = [
 		new(winston.transports.Console)({
-			level: 'debug',
+			level: config.consoleLevel,
 			colorize: config.colorize
 		})
 	];
@@ -36,20 +45,43 @@ module.exports = function CaptainsLog ( config ) {
 				filename: config.filePath,
 				maxsize: config.maxSize,
 				maxFiles: config.maxFiles,
-				level: 'verbose',
+				level: config.fileLevel,
 				json: config.json,
-				colorize: config.colorize
+				colorize: false,
+				stripColors: true
 			}));
 	}
 
 	var logLevels = {
-		silly: 6,
-		verbose: 5,
-		info: 4,
-		debug: 3,
-		warn: 2,
-		error: 1,
-		silent: 0
+	    silly: 0,
+	    verbose: 1,
+	    info: 2,
+	    notice: 2,
+	    debug: 3,
+	    alert: 4,
+	    warn: 4,
+	    warning: 4,
+	    error: 5,
+	    crit: 6,
+	    emerg: 6,
+	    fail: 6,
+	    silent: 7
+	};
+
+	var logColors = {
+	    silly: 'cyan',
+	    verbose: 'cyan',
+	    info: 'green',
+	    notice: 'green',
+	    debug: 'blue',
+	    alert: 'yellow',
+	    warn: 'yellow',
+	    warning: 'yellow',
+	    error: 'red',
+	    crit: 'red',
+	    emerg: 'red',
+	    fail: 'red',
+	    silent: 'white'
 	};
 
 	// if adapter option is set, ALSO write log output to an adapter
@@ -73,6 +105,8 @@ module.exports = function CaptainsLog ( config ) {
 
 	// Instantiate winston
 	var logger = new(winston.Logger)({
+		levels: logLevels,
+		colors: logColors,
 		transports: transports
 	});
 
@@ -147,12 +181,8 @@ module.exports = function CaptainsLog ( config ) {
 			});
 			str = pieces.join(' ');
 
-
-			// Print out output if log level is below configured log level
-			if ( logLevels[level] <= logLevels[config.level] ) {
-				var fn = logger[level];
-				fn(str);
-			}
+			var fn = logger[level];
+			fn(str);
 		};
 	}
 };

--- a/lib/hooks/logger/index.js
+++ b/lib/hooks/logger/index.js
@@ -26,7 +26,9 @@ module.exports = function(sails) {
 				maxSize: 10000000,
 				maxFiles: 10,
 				json: false,
-				colorize: true
+				colorize: true,
+				consoleLevel: 'undefined',
+				fileLevel: 'undefined'
 			}
 		},
 


### PR DESCRIPTION
Separate out logging settings for the console and for the file logging. Log level checking needs to be done at the Winston adapter level not at the top log level.

I added many log levels used by various Node modules for possible later use. Some of them are variants on the same log level.

Also, I _strongly_ suggest flipping the debug and info priority levels. It makes no sense to have debug at a higher level then info. They are _not_ flipped in this patch, they are left as they were.
