### PR TITLE
Use grunt-sync to only copy static files when they are modified

### DIFF
--- a/bin/generators/app/templates/Gruntfile.js
+++ b/bin/generators/app/templates/Gruntfile.js
@@ -133,6 +133,7 @@ module.exports = function (grunt) {
   grunt.loadTasks(depsPath + '/grunt-contrib-cssmin/tasks');
   grunt.loadTasks(depsPath + '/grunt-contrib-less/tasks');
   grunt.loadTasks(depsPath + '/grunt-contrib-coffee/tasks');
+  grunt.loadTasks(depsPath + '/grunt-sync/tasks');
 
   // Project configuration.
   grunt.initConfig({
@@ -158,6 +159,16 @@ module.exports = function (grunt) {
           dest: 'www'
         }
         ]
+      }
+    },
+
+    sync: {
+      dev: {
+        files: [{
+          cwd: './assets',
+          src: ['**/*.!(coffee)'],
+          dest: '.tmp/public'
+        }]
       }
     },
 
@@ -428,7 +439,7 @@ module.exports = function (grunt) {
         files: ['assets/**/*'],
 
         // When assets are changed:
-        tasks: ['compileAssets', 'linkAssets']
+        tasks: ['syncAssets', 'linkAssets']
       }
     }
   });
@@ -445,6 +456,13 @@ module.exports = function (grunt) {
     'jst:dev',
     'less:dev',
     'copy:dev',    
+    'coffee:dev'
+  ]);
+
+  grunt.registerTask('syncAssets', [
+    'jst:dev',
+    'less:dev',
+    'sync:dev',
     'coffee:dev'
   ]);
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "connect-flash": "0.1.1",
     "pluralize": "0.0.5",
     "json-stringify-safe": "5.0.0",
-    "captains-log": "~0.10.5"
+    "captains-log": "~0.10.5",
+    "grunt-sync": "0.0.4"
   },
   "devDependencies": {
     "checksum": "~0.1.1",


### PR DESCRIPTION
This pr uses `grunt-sync` to only copy static files that have changed. This significantly improves my dev experience when working with sails because I spent much less time waiting for files to be copied to the .tmp directory after making a change to my client side js files.

This pr was in response to issue #719 I also suspect it will help when using bower like in #1122.

Unfortunately `.less` `.jst` `.coffee` files are still copied and compiled every time. I'm not using may of these files formats currently so I have not noticed a problem but I suspect coffeescript projects will still experience a significant delay while `.coffee` files are compiling.
