### PR TITLE
Use the filename as the table name by default.

### DIFF
--- a/lib/hooks/orm/index.js
+++ b/lib/hooks/orm/index.js
@@ -67,7 +67,7 @@ module.exports = function(sails) {
 			// Implicit framework defaults
 			var implicitDefaults = {
 				identity: modelID,
-				tableName: modelID
+				tableName: modelDef.globalId
 			};
 
 			// App defaults from `sails.config.model`


### PR DESCRIPTION
As Sails document describes,  if no table name is supplied it will use the filename as the table name when passing it to an adapter.
