### PR TITLE
Removed second backslash from pathToSails which caused grunt to fail

### DIFF
--- a/lib/hooks/grunt/index.js
+++ b/lib/hooks/grunt/index.js
@@ -41,7 +41,7 @@ module.exports = function (sails) {
 			var environment = sails.config.environment;
 			var baseurl = 'http://' + (sails.config.host || 'localhost') + ':' + sails.config.port;
 			var signalpath = '/___signal';
-			var pathToSails = __dirname.replace(' ', '\\ ') + '/../../..';
+			var pathToSails = __dirname.replace(' ', '\ ') + '/../../..';
 
 			if (!taskName) {
 				taskName = '';


### PR DESCRIPTION
This is in reference to Issue #1040 where grunt was failing due to a path issue.
