### PR TITLE
Pass calculated id to pubsub on destroy.

### DIFF
--- a/lib/hooks/controllers/controller.destroy.js
+++ b/lib/hooks/controllers/controller.destroy.js
@@ -50,7 +50,7 @@ module.exports = function (sails) {
 				// If the model is silent, don't use the built-in pubsub
 				// (also ignore pubsub logic if the hook is not enabled)
 				if (sails.hooks.pubsub && !Model.silent) {
-					Model.publishDestroy(result.id); // req.socket
+					Model.publishDestroy(id); // req.socket
 				}
 
 				// Interlace app-global `config.controllers` with this controller's `_config`


### PR DESCRIPTION
Use the original id calculated before deleting to pass to pubsub
instead of the id returned by the deletion operation.

The idHelper function was used to help determine the value and
a proper id may not be returned by the deletion result function.

There is no apparent reason not to use the original id for both cases.

I am using an underlying document database that uses "_id" as the id.
Generally, this works well except when deleting items with pubsub active.
The database returns "result._id" and "result.id" is undefined causing the
Model.publishDestroy method to throw an exception.
The proper "id" values is calculated above to perform the deletion,
so I am not sure why this same value is not used for publishDestroy.
