### PR TITLE
Set the dependency for new sails projects to the v0.10 branch

### DIFF
--- a/bin/generators/new/index.js
+++ b/bin/generators/new/index.js
@@ -189,7 +189,7 @@ module.exports = {
 
 				// Override sails version temporarily
 				var sailsVersionDependency = '~' + sails.version;
-				sailsVersionDependency = 'git://github.com/balderdashy/sails.git#associations';
+				sailsVersionDependency = 'git://github.com/balderdashy/sails.git#v0.10';
 
 				// Generate package.json file
 				GenerateJSONHelper({


### PR DESCRIPTION
When using the latest version for sails from the `v0.10` branch. Running `sails new foo` creates a new sails project were the dependency is on the `associations` branch. This causes `sails lift` to throw errors. Setting the dependency to the `v0.10` branch fixes this issue.
