### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "grunt-contrib-uglify": "0.2.2",
     "grunt-contrib-cssmin": "0.6.1",
     "grunt-contrib-less": "~0.8.3",
-    "grunt-contrib-coffee": "0.7.0"
+    "grunt-contrib-coffee": "0.7.0",
+    "node-switchback": "0.0.4"
   },
   "devDependencies": {
     "checksum": "~0.1.1",


### PR DESCRIPTION
`sails new app` was borked. It requires `node-switchback` which hasn't been added to the dependencies.

**Update:**
I've added the output from my terminal to prove I'm not making this up:

```
rwoverdijk@WesMac ~/projects/nodejs/just-write
$ sails new sandbox

/usr/local/lib/node_modules/sails/bin/generators/factory.js:21
        throw new Error(
              ^
Error: Generator, `'new'` failed to load ( @ '/usr/local/lib/node_modules/sails/bin/generators/new')
Error: Generator, `'assetsDirectory'` failed to load ( @ '/usr/local/lib/node_modules/sails/bin/generators/assetsDirectory')
Error: Cannot find module 'node-switchback'
    at module.exports (/usr/local/lib/node_modules/sails/bin/generators/factory.js:21:9)
    at Object.CLIController [as new] (/usr/local/lib/node_modules/sails/bin/index.js:55:18)
    at interpretArguments (/usr/local/lib/node_modules/sails/bin/arguments.js:152:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/sails/bin/index.js:425:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
```
