### PR TITLE
Exclude *.less files from being copied to public

### DIFF
--- a/bin/boilerplates/Gruntfile.js
+++ b/bin/boilerplates/Gruntfile.js
@@ -144,7 +144,7 @@ module.exports = function (grunt) {
           {
           expand: true,
           cwd: './assets',
-          src: ['**/*.!(coffee)'],
+          src: ['**/*.!(coffee|less)'],
           dest: '.tmp/public'
         }
         ]


### PR DESCRIPTION
I noticed `*.less` files were making it into `.tmp/public` during lift and since Sails supports LESS by default, I assumed that those should be excluded from the assets copy in the Gruntfile, just like the CoffeeScript files are currently.
