### PR TITLE
use empty array if no collections have been initialized

### DIFF
--- a/lib/hooks/orm/index.js
+++ b/lib/hooks/orm/index.js
@@ -314,7 +314,7 @@ module.exports = function(sails) {
 		 *						stack.instantiatedCollections {}
 		 */
 		exposeModels: function (cb, stack) {
-			var collections = stack.instantiatedCollections.collections;
+			var collections = stack.instantiatedCollections.collections = [];
 
 			Object.keys(collections).forEach(function eachInstantiatedCollection (modelID) {
 


### PR DESCRIPTION
A freshly made sails app will not lift since it does not have any collections yet.
