### PR TITLE
fixed typo on sails-disk dependency for sailsjs, relates to #1368

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "connect-mongo": "~0.3.2",
     "grunt-cli": "~0.1.11",
     "ejs": "~0.8.4",
-    "sails-disk": "git://github.com/balderdashy/sails-disk.git#0.10.beta",
+    "sails-disk": "git://github.com/balderdashy/sails-disk.git#v0.10",
 
     "commander": "~2.1.0",
     "enpeem": "~0.1.1",


### PR DESCRIPTION
#1368 reported that sails-disk `package.json` on sails#master may have been specified wrong.

The typo still works, probably ref's a commit but shouldn't it point to the branch?
