### PR TITLE
move defaults to instantiation and send all but save method to Session.s...

### DIFF
--- a/lib/hooks/session/index.js
+++ b/lib/hooks/session/index.js
@@ -32,6 +32,8 @@ module.exports = function (sails) {
 		var sid = options.sid,
 			data = options.data;
 
+    // Merge data directly into instance to allow easy access on `req.session` later
+    util.defaults(this, data);
 
 		this.save = function (cb) {
 			
@@ -42,11 +44,8 @@ module.exports = function (sails) {
 				return;
 			}
 
-			// Merge data directly into instance to allow easy access on `req.session` later
-			util.defaults(this, data);
-
 			// Persist session
-			Session.set(sid, data, function (err) {
+			Session.set(sid, _.omit(this,'save'), function (err) {
 				if (err) {
 					sails.log.error('Could not save session:');
 					sails.log.error(err);


### PR DESCRIPTION
Session data with sockets is not being saved properly.

`data` is being set on instantiation but never updated with current session data.  The `save` function uses `data` as defaults for `this` but then sends a unmodified `data` object on to `Session.get`. 

This PR sets defaults upon instantiation then sends the updated `this` object (minus `save`) to `Session.get`

Tested with Memory and Mongo adapters.
