### PR TITLE
Fixing swig cache settings

### DIFF
--- a/lib/hooks/views/consolidate.js
+++ b/lib/hooks/views/consolidate.js
@@ -284,6 +284,7 @@ module.exports = function(sailsAppPath) {
   fns.swig.render = function(str, options, fn){
     var engine = requires.swig || (requires.swig = require(sailsAppPath + '/swig'));
     try {
+      if(options.cache === true) options.cache = 'memory';
       var tmpl = cache(options) || cache(options, engine.compile(str, options));
       fn(null, tmpl(options));
     } catch (err) {


### PR DESCRIPTION
If `options.cache === true`, swig expects that value to equal `'memory'`.  Otherwise, it throws an error.
