### PR TITLE
Fixing swig cache

### DIFF
--- a/lib/hooks/views/consolidate.js
+++ b/lib/hooks/views/consolidate.js
@@ -284,6 +284,7 @@ module.exports = function(sailsAppPath) {
   fns.swig.render = function(str, options, fn){
     var engine = requires.swig || (requires.swig = require(sailsAppPath + '/swig'));
     try {
+      if(options.cache === true) options.cache = 'memory';
       var tmpl = cache(options) || cache(options, engine.compile(str, options));
       fn(null, tmpl(options));
     } catch (err) {


### PR DESCRIPTION
In production, if `options.cache === true`, swig expects the value returned to be `'memory'`, otherwise an error is thrown.
## To test

Run `sails lift` using the swig templating engine and navigate to any page—the result should be a 500 error on the client and the following in the log:

``` bash
error: Error rendering view at ::
error: Using layout located at ::
error: Server Error (500)
error: Error: Invalid cache option true found. Expected "memory" or { get: function (key) { ... }, set: function (key, value) { ... } }.
```

Swig will only throw this in production, so running `NODE_ENV=production sails lift` will get you there with a local copy.
## Source

The latest version of consolidate.js patches this:
https://github.com/visionmedia/consolidate.js/commit/e84860d55b2cb938c9a5525f83feba7f86dfeba7#diff-5c63ce9751803a854df2e222cea263e8

With the relevant line being this one:
https://github.com/visionmedia/consolidate.js/blob/master/lib/consolidate.js#L246
