### PR TITLE
Add missing Mocha test dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "should": "~2.1.1",
     "supertest": "~0.8.2",
     "fs-extra": "~0.8.1",
-    "socket.io-client": "~0.9.16"
+    "socket.io-client": "~0.9.16",
+    "mocha": "~1.17.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Having Mocha installed globally masks this error, but Travis is failing to run tests because it can't find Mocha. This fixes that.
