### PR TITLE
Fix Sails startup error in load test, ensure tests use open ports

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "supertest": "~0.8.2",
     "fs-extra": "~0.8.1",
     "socket.io-client": "~0.9.16",
-    "mocha": "~1.17.1"
+    "mocha": "~1.17.1",
+    "portfinder": "~0.2.1"
   },
   "repository": {
     "type": "git",

--- a/test/benchmarks/sails.load.test.js
+++ b/test/benchmarks/sails.load.test.js
@@ -1,6 +1,8 @@
 
 
 var _ = require('lodash');
+var portfinder = require('portfinder');
+portfinder.basePort = 2001;
 
 var SHOW_VERBOSE_BENCHMARK_REPORT = _.any(process.argv, function(arg) {
 	return arg.match(/-v/);
@@ -98,11 +100,15 @@ describe('benchmarks', function () {
 
 			var Sails = require('../../lib/app');
 			var sails = new Sails();
-			sails.lift({
-				log: { level: 'error' },
-				port: 2001,
-				globals: false
-			}, cb);
+			portfinder.getPort(function (err, port) {
+				if (err) throw err;
+
+				sails.lift({
+					log: { level: 'error' },
+					port: port,
+					globals: false
+				}, cb);
+			});
 		});
 
 		benchmark('sails.lift  [again, w/ a hot require cache]', function(cb) {
@@ -110,11 +116,15 @@ describe('benchmarks', function () {
 
 			var Sails = require('../../lib/app');
 			var sails = new Sails();
-			sails.lift({
-				log: { level: 'error' },
-				port: 2001,
-				globals: false
-			}, cb);
+			portfinder.getPort(function (err, port) {
+				if (err) throw err;
+
+				sails.lift({
+					log: { level: 'error' },
+					port: port,
+					globals: false
+				}, cb);
+			});
 		});
 
 	});


### PR DESCRIPTION
Previously, test runs were throwing an error about port 2001 not being open (see [this example Travis output](https://travis-ci.org/balderdashy/sails/builds/19410416#L1149) to see what I mean). Ostensibly that means that particular load test wasn't actually running.

I use this approach (letting `portfinder` find an open port for me) in my own app's tests to be sure I'm using an open port. Now that I'm typing this, I'm realizing it probably taints the load tests a bit. It also feels a little heavy-handed compared to calling `sails.lower` after each test run, but even when I did that it was throwing errors about port 2001 not being open. Could be a bug in `sails.lower`, more likely a bug in my understanding of `sails.lower`.
