### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{ejs,html}]
+indent_style = space
+indent_size = 4
+
+[*.md]
+# GitHub flavored markdown lets you use two trailing spaces as a linebreak
+trim_trailing_whitespace = false


### PR DESCRIPTION
http://editorconfig.org/

I normally use spaces, so I like using `.editorconfig`s so my editor respects the project's style. Cursory glance at `.jshintrc` says this is the project's style, let me know if anything looks funky
