### PR TITLE
Allow controller to override its `req.model`.

### DIFF
--- a/lib/hooks/blueprints/index.js
+++ b/lib/hooks/blueprints/index.js
@@ -216,9 +216,11 @@ module.exports = function(sails) {
 				}
 			});
 
-      // Get the model connected to this controller either by explicit configuration
-      // or implicit by controller id
-      var modelId = config.model || controllerId;
+			// Get the model connected to this controller either by explicit configuration
+			// on the controller or the routes config
+      			// or implicit by controller id
+      			var routeConfig = sails.router.explicitRoutes[controllerId] || {};
+			var modelId = config.model || routeConfig.model || controllerId;
 
 			// If the orm hook is enabled, it has already been loaded by this time,
 			// so just double-check to see if `sails.models` exists before trying to


### PR DESCRIPTION
Allows controllers to override the model id passed into `req.model`:

``` javascript
// api/controllers/ThisController.js
module.exports = {
  _config: {
    model: 'that'
  }
}
```

Would enable blueprint routes for `/this/*`, using a hypothetical model `That`.

Most prominent use case would be a short-term solution for namespaced controllers missing out on all blueprint functionality as there is no possibility to namespace models at the moment. 
