### PR TITLE
fixes #1444

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -814,7 +814,7 @@ module.exports = function(sails) {
 								if (reverseAssociation.type == 'model') {
 									var pubData = {};
 									pubData[reverseAssociation.alias] = null;
-									ReferencedModel.publishUpdate(previous[association.alias][ReferencedModel.primaryKey], pubData, {noReverse:true});
+									ReferencedModel.publishUpdate(previous[association.alias], pubData, {noReverse:true});
 								} 
 								// If it's a to-many, publish a "removed" alert
 								else {


### PR DESCRIPTION
https://github.com/balderdashy/sails/issues/1444

The error was being thrown due to no id value being presented to the publishUpdate method. This was due to an improper reference to the associated model's id value.

I do not know if this pertains as well to the to-many relationship, as I was dealing with a one-to-many relationship.

An id value will now be properly presented. The ReferencedModel.primaryKey (which equals id) was being called on an integer, causing no value to be presented.
