### PR TITLE
Fix a crash with mixed case models

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -1079,7 +1079,7 @@ module.exports = function(sails) {
 					// Bail if this attribute isn't in the model's schema
 					if (referencedModel) {
 						// Get the associated model class
-						var ReferencedModel = sails.models[referencedModel];
+						var ReferencedModel = sails.models[referencedModel.toLowerCase()];
 						// Get the inverse association definition, if any
 						reverseAssociation = _.find(ReferencedModel.associations, {collection: this.identity}) || _.find(ReferencedModel.associations, {model: this.identity});
 


### PR DESCRIPTION
The sails.models object keys are lower case, and Reference Model may be
mixed case. As promised without the white space deletions :)
