### PR TITLE
Fixed comment usage example

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -199,7 +199,7 @@ module.exports = function(sails) {
 		 * Broadcast a message to all connected sockets
 		 *
 		 * If the event name is omitted, sails.sockets.DEFAULT_EVENT_NAME will be used by default.
-		 * Thus, sails.sockets.broadcast(data) is also a valid usage.
+		 * Thus, sails.sockets.blast(data) is also a valid usage.
 		 *
 		 * @param  {string} event    The event name to broadcast
 		 * @param  {object} data     The data to broadcast


### PR DESCRIPTION
This comment meant to show an example usage of .blast() but it said .broadcast()
