### PR TITLE
#1445 bug issue

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -701,7 +701,9 @@ module.exports = function(sails) {
 				if (options.previous && !options.noReverse) {
 
 					var previous = options.previous;
-
+					
+					
+					
 					// If any of the changes were to association attributes, publish add or remove messages.
 					_.each(changes, function(val, key) {
 
@@ -825,6 +827,14 @@ module.exports = function(sails) {
 
 							if (reverseAssociation) {
 								// If it's a to-one, publish a simple update alert
+								
+								//if the previous object passed in was passed in with an association object rather than a number
+								if(typeof previous === 'object'){
+									var tempID = previous[association.alias][ReferencedModel.primaryKey]
+									delete previous[association.alias]
+									previous[association.alias] = tempID
+								}
+								
 								if (reverseAssociation.type == 'model') {
 									var pubData = {};
 									pubData[reverseAssociation.alias] = null;
@@ -832,7 +842,7 @@ module.exports = function(sails) {
 								} 
 								// If it's a to-many, publish a "removed" alert
 								else {
-									ReferencedModel.publishRemove(previous[association.alias][ReferencedModel.primaryKey], reverseAssociation.alias, id, req, {noReverse:true});
+									ReferencedModel.publishRemove(previous[association.alias], reverseAssociation.alias, id, req, {noReverse:true});
 								}
 							}
 						}


### PR DESCRIPTION
https://github.com/balderdashy/sails/pull/1445

This change is only valid if the previous model that was found via Cell.findOne, did not include a populate query.

```
            function deleteOldCell(callBack){
                Cell.findOne(cell.id).exec(function (err,c){
                    if(err){
                        callBack(err)
                    }
                    if(!c || c.length === 0){
                        callBack(null)
                    } else {
                        Cell.destroy({id:c.id}).exec(function (err){
                            if(err){
                                callBack(err)
                            } else {
                                Cell.publishDestroy(c.id,false,{previous:c})
                                callBack(null)
                            }                               
                        })
                    }
                })
            }
```

In the event that a populate query was made, such as this:

```
            function deleteOldCell(callBack){
                Cell.findOne(cell.id).populate('grid').exec(function (err,c){
                    if(err){
                        callBack(err)
                    }
                    if(!c || c.length === 0){
                        callBack(null)
                    } else {
                        Cell.destroy({id:c.id}).exec(function (err){
                            if(err){
                                callBack(err)
                            } else {
                                Cell.publishDestroy(c.id,false,{previous:c})
                                callBack(null)
                            }                               
                        })
                    }
                })
            }
```

the old version:

ReferencedModel.publishUpdate(previous[association.alias][ReferencedModel.primaryKey]
is a valid reference, since the previous value's association.alias will be a object instead of a number.

There has to be some kind of checking to see whether the previous value being passed in is an object or not and pass in the correct key.

This patch should fix this issue. I have not tested it but I am running a version of it in my controller.
