### PR TITLE
dones't disable bodyParser middleware on 0.9.x

### DIFF
--- a/lib/express/index.js
+++ b/lib/express/index.js
@@ -23,8 +23,7 @@ module.exports = function (sails) {
 
 
 		var bodyParserEnabled = util.isFunction(sails.config.express.bodyParser),
-			bodyParserRetryEnabled = sails.config.express.retryBodyParserWithJSON,
-			bodyParser = sails.config.express.bodyParser();
+			bodyParserRetryEnabled = sails.config.express.retryBodyParserWithJSON;
 
 		// Define housing object for Express in the Sails namespace
 		sails.express = {};
@@ -109,6 +108,7 @@ module.exports = function (sails) {
 	  
 		// Use body parser, if enabled
 		if (bodyParserEnabled) {
+			var bodyParser = sails.config.express.bodyParser();
 			app.use(function(req, res, next) {
 			  
 				// Body parser can be disabled per-request for streaming file uploads


### PR DESCRIPTION
I want to disable bodyParser middleware on Sails0.9.x.
So, I changed configuration like that.

``` js
  express: {
    bodyParser: false
  }
```

However, I cannot disable it, because `lib/express/index.js` is calling `sails.config.express.bodyParser()`.
