### PR TITLE
add support for connect-to-mongo session store

### DIFF
--- a/lib/hooks/session/index.js
+++ b/lib/hooks/session/index.js
@@ -146,6 +146,9 @@ module.exports = function (sails) {
 					case 'mongo':
 						sessionConfig.store = new(require('connect-mongo')(require('express')))(sessionConfig);
 						break;
+					case 'connect-to-mongo':
+						sessionConfig.store = new(require('connect-to-mongo')(require('express')))(sessionConfig);
+						break;
 
 					// Unknown session adapter
 					default:

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "sails-build-dictionary": "0.1.0",
     "connect-redis": "~1.4.5",
     "connect-mongo": "~0.3.2",
+    "connect-to-mongo": "~0.1.2",
     "grunt-cli": "~0.1.11",
     "ejs": "~0.8.4",
     "sails-disk": "~0.10.0",


### PR DESCRIPTION
"connect-to-mongo" [https://github.com/2do2go/connect-to-mongo] is simply clone of "connect-redis" session store (connect-mongo deliver some problems).
