### PR TITLE
Plugin system

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -126,7 +126,7 @@ module.exports = function(sails) {
             dirname   : sails.config.paths.config || sails.config.appPath + '/config',
             exclude   : ['locales', 'local.js', 'local.json', 'local.coffee'],
             excludeDirs: ['locales'],
-            filter    : /local\.(js|json|coffee)$/,
+            filter    : /(.+)\.(js|json|coffee)$/,
             identity  : false
           }, cb);
         },
@@ -135,7 +135,7 @@ module.exports = function(sails) {
         'config/local' : function loadLocalOverrideFile (cb) {
           buildDictionary.aggregate({
             dirname   : sails.config.paths.config || sails.config.appPath + '/config',
-            filter    :  /(.+)\.(js|json|coffee)$/,
+            filter    : /local\.(js|json|coffee)$/,
             identity  : false
           }, cb);
         }


### PR DESCRIPTION
Hello,
This pull request is more of a proposition rather than a straightforwardly acceptable piece of code.

What I intend to demonstrate through this request is how one could load models and controllers from a npm package present into the dependencies of your `package.json`.

The idea is to add an array of plugin names to the sails config, in the `.sailsrc` file for instance:

``` json
{
  "generators": {
    "modules": {}
  },
  "plugins": [
    "plugin-test"
  ]
}
```

Then, the module loader will load and merge (with priority given to the main files meaning that the main app would override the plugins' files and not the other way around), models and controllers from the npm  `plugin-test` package, making those available for the app.
## Naming

I use the word `plugin` to describe the behaviour I intent to create here but this is a mere proposition.
## Convention?

I followed sails' convention by loading controllers and models from a npm package being respectively in the `controllers` and `models` folders of the said package.

Example

```
sailsapp/
    usual sails files...
    node_modules/
        plugin-test/
            package.json
            controllers/
                TestController.js
            models/
                Test.js
```

Maybe a way through require and a clever index.js might be better.
## Relevant?

If you find those ideas relevant, I am willing to finish the code I started and load adapters, hooks, policies etc. I could as well develop the task enabling to copy into `.tmp` the assets coming from a npm package and why not a plugin configuration system.
