### PR TITLE
remove conflict with sugar.js Array.all() method

### DIFF
--- a/lib/hooks/controllers/controller.create.js
+++ b/lib/hooks/controllers/controller.create.js
@@ -24,7 +24,7 @@ module.exports = function (sails) {
 		}
 		
 		// Create monolithic parameter object
-		var params = req.params.all();
+		var params = req.params.allParams();
 		
 		// Don't include JSONP callback parameter as data
 		params = util.objReject(params, function (param, key) {

--- a/lib/hooks/controllers/controller.find.js
+++ b/lib/hooks/controllers/controller.find.js
@@ -92,7 +92,7 @@ module.exports = function (sails) {
 			if (!where) {
 				
 				// Build monolithic parameter object
-				params = req.params.all();
+				params = req.params.allParams();
 
 				// Pluck params:
 				params = util.objReject(params, function (param, key) {

--- a/lib/hooks/controllers/controller.update.js
+++ b/lib/hooks/controllers/controller.update.js
@@ -32,10 +32,10 @@ module.exports = function (sails) {
 
 
 		// Create monolithic parameter object
-		var params = req.params.all();
+		var params = req.params.allParams();
 
 		// Build monolithic parameter object
-		params = req.params.all();
+		params = req.params.allParams();
 
 		// Don't include JSONP callback parameter as data
 		params = util.objReject(params, function (param, key) {

--- a/lib/hooks/request/index.js
+++ b/lib/hooks/request/index.js
@@ -219,7 +219,7 @@ module.exports = function(sails) {
 
 	/**
 	 * Some syntactic sugar
-	 * e.g. `req.params.all()`
+	 * e.g. `req.params.allParams()`
 	 *
 	 * Note: this has to be applied per-route, not per request,
 	 * in order to refer to the proper route/path parameters
@@ -249,17 +249,17 @@ module.exports = function(sails) {
 			allParams[paramName] = req.params[paramName];
 		});
 
-		// Define a new non-enuerable function: req.params.all()
+		// Define a new non-enuerable function: req.params.allParams()
 		// (but only if an `:all` route parameter doesn't exist)
-		if (!req.params.all) {
-			Object.defineProperty(req.params, 'all', {
+		if (!req.params.allParams) {
+			Object.defineProperty(req.params, 'allParams', {
 				value: function getAllParams() {
 					return allParams;
 				}
 			});
 		}
 
-		// TODO: make req.params() do the same thing as req.params.all() ??
+		// TODO: make req.params() do the same thing as req.params.allParams() ??
 
 	}
 


### PR DESCRIPTION
Fixes incompatibility with sugarjs npm package.

Specifically sugar applies an 'all' method to arrays.
http://sugarjs.com/api/Array/all
