### PR TITLE
Merge locals with with config views options

### DIFF
--- a/lib/hooks/views/res.view.js
+++ b/lib/hooks/views/res.view.js
@@ -86,7 +86,7 @@ module.exports = function _addResViewMethod(req, res, next) {
 		
 		// Merge with config views locals
 		if (sails.config.views.locals) {
-			_.defaults(locals, sails.config.views.locals);
+			_.merge(locals, sails.config.views.locals, _.defaults);
 		}
 		
 		// If the path was specified, but invalid


### PR DESCRIPTION
Adding `sails.config.views.options` to be merged with `locals` in `res.view()`.

example usage:

``` javascript
// ../config/views.js

module.exports.views = {
  engine  : 'jade',
  layout  : false,
  options : {
    basedir : '/path/to/includes/basedir'
  }
};
```

I'm not sure this is the best way, but I did not see a way to configure options for `res.view()` on an app level (other than adding a custom bootstrap/middleware). There might be a better place to merge the options, or maybe it already does and I missed the config option.

**_p.s.**_ I did not see a good place for a test for this. If something like this is a good idea I'll go back and add a test.
