### PR TITLE
Pub/sub: wrapper for sails.sockets.broadcast

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -315,6 +315,24 @@ module.exports = function(sails) {
 
     return {
 
+      /**
+       * Broadcast a message to a room
+       *
+       * Wrapper for sails.sockets.broadcast
+       * Can be overridden at a model level, i.e. for encapsulating messages within a single event name.
+       *
+       * @param  {string} roomName The room to broadcast a message to
+       * @param  {string} eventName    The event name to broadcast
+       * @param  {object} data     The data to broadcast
+       * @param  {object} socket   Optional socket to omit
+       *
+       * @api private
+       */
+
+      broadcast: function(roomName, eventName, data, socketToOmit) {
+        sails.sockets.broadcast(roomName, eventName, data, socketToOmit);
+      },
+
 
       /**
        * TODO: document
@@ -365,7 +383,7 @@ module.exports = function(sails) {
             data: data
           };
 
-          sails.sockets.broadcast( room, this.identity, payload, socketToOmit );
+          this.broadcast( room, this.identity, payload, socketToOmit );
           sails.log.silly("Published message to ", room, ": ", payload);
 
         }
@@ -426,7 +444,7 @@ module.exports = function(sails) {
           STRINGFILE.logUpgradeNotice(STRINGFILE.get('upgrade.classrooms'), [], sails.log.debug);
 
           sails.log.silly('Published ', eventName, ' to ', self.classRoom());
-          sails.sockets.broadcast( self.classRoom(), eventName, data, socketToOmit );
+          self.broadcast( self.classRoom(), eventName, data, socketToOmit );
           return;
         }
 
@@ -440,7 +458,7 @@ module.exports = function(sails) {
           _.each(ids,function eachInstance (id) {
             var room = self.room(id, context);
             sails.log.silly("Published ", eventName, " to ", room);
-            sails.sockets.broadcast( room, eventName, data, socketToOmit );
+            self.broadcast( room, eventName, data, socketToOmit );
           });
         }
 
@@ -1141,7 +1159,7 @@ module.exports = function(sails) {
         });
 
         // Publish to classroom
-        sails.sockets.broadcast(this._classRoom(), this.identity, {
+        this.broadcast(this._classRoom(), this.identity, {
           verb: 'created',
           data: values,
           id: values[this.primaryKey]


### PR DESCRIPTION
Hi,

I've added a wrapper for sails.sockets.broadcast inside the default Model pub/sub methods. This will allow a Model to override and modify broadcasts, for example to encapsulate with a different event name.

Cheers
