### PR TITLE
Option to set the populate settings from the association itself

### DIFF
--- a/lib/hooks/blueprints/actionUtil.js
+++ b/lib/hooks/blueprints/actionUtil.js
@@ -40,7 +40,20 @@ module.exports = {
       // of the association attribute, and value is true/false (true to populate,
       // false to not)
       if (options.populate){
-        return query.populate(association.alias, { limit: DEFAULT_POPULATE_LIMIT });
+
+        // Default populate settings
+        var populateSettings = {
+          limit: DEFAULT_POPULATE_LIMIT
+        };
+
+        // Try to get the populate settings from the association
+        // 
+        // {collection: 'users', 'via': 'owner': populateSettings: {limit: 20, sort: 'name ASC'}}
+        if (association.populateSettings) {
+          populateSettings = association.populateSettings;
+        }
+
+        return query.populate(association.alias, populateSettings);
       }
       else return query;
     }, query);


### PR DESCRIPTION
With this change, you can set the populate settings of an association directly in the association object itself.
This allows the developer to continue using the blueprint for REST apis even when the association has to be limited, sorted or filtered in a different way that the standard one