### PR TITLE
Change module existance check

### DIFF
--- a/lib/hooks/orm/index.js
+++ b/lib/hooks/orm/index.js
@@ -467,18 +467,17 @@ module.exports = function(sails) {
 
 			// Since it is unknown so far, try and load the adapter from `node_modules`
 			sails.log.verbose('Loading adapter (', moduleName, ') for ' + modelID, ' from `node_modules` directory...');
-			var modulePath = sails.config.appPath + '/node_modules/' + moduleName;
-			if ( !fs.existsSync (modulePath) ) {
-				// If adapter doesn't exist, log an error and exit
-				return Err.fatal.__UnknownAdapter__ (connectionObject.adapter, modelID, sails.majorVersion, sails.minorVersion);
-			}
-
-			// Since the module seems to exist, try to require it (execute the code)
 			try {
-				sails.adapters[moduleName] = require(modulePath);
+				sails.adapters[moduleName] = require(moduleName);
 			}
 			catch (err) {
-				return Err.fatal.__InvalidAdapter__ (moduleName, err);
+				if(err.code === 'MODULE_NOT_FOUND') {
+					// If adapter doesn't exist, log an error and exit
+					return Err.fatal.__UnknownAdapter__ (connectionObject.adapter, modelID, sails.majorVersion, sails.minorVersion);
+				}
+				else {
+					return Err.fatal.__InvalidAdapter__ (moduleName, err);
+				}
 			}
 		}
 


### PR DESCRIPTION
Now you are checking hard-coded directory. But not everywhere modules are located there. This fix allows modules to be anywhere when it could be get using require function.
For example, I keep sails app in nested directory and override `appPath` to make it work. In this case it raises an error about missing module, but module is accessible using require function.
