### PR TITLE
Enable CORS of /csrfToken for whitelisted origins

### DIFF
--- a/lib/hooks/csrf/index.js
+++ b/lib/hooks/csrf/index.js
@@ -27,13 +27,15 @@ module.exports = function(sails) {
       if (sails.config.csrf === true) {
         sails.config.csrf = {
           grantTokenViaAjax: true,
-          protectionEnabled: true
+          protectionEnabled: true,
+          origin: ''
         };
       }
       else if (sails.config.csrf === false) {
         sails.config.csrf = {
           grantTokenViaAjax: false,
-          protectionEnabled: false
+          protectionEnabled: false,
+          origin: ''
         };
       }
       // If user provides ANY object (including empty object), enable all default
@@ -41,7 +43,8 @@ module.exports = function(sails) {
       else {
         _.defaults(typeof sails.config.csrf === 'object' ? sails.config.csrf : {}, {
           grantTokenViaAjax: true,
-          protectionEnabled: true
+          protectionEnabled: true,
+          origin: ''
         });
       }
     },
@@ -51,8 +54,9 @@ module.exports = function(sails) {
 
       before: {
         '/*': function(req, res, next) {
+          var allowCrossOriginCSRF = sails.config.csrf.origin.split(',').indexOf(req.headers.origin) > -1;
 
-          if (sails.config.csrf.protectionEnabled && (!req.headers.origin || util.isSameOrigin(req))) {
+          if (sails.config.csrf.protectionEnabled && (!req.headers.origin || util.isSameOrigin(req) || allowCrossOriginCSRF)) {
             var connect = require('express/node_modules/connect');
 
             return connect.csrf()(req, res, function(err) {


### PR DESCRIPTION
Allows sails.config.csrf.allowCORS to be set (boolean) in order to specify whether or not you would like /csrfToken to be accessible in cross-domain AJAX requests. Prior to this fix, all CORS requsts to /csrfToken returned a null CSRF token.
