### PR TITLE
additive (i.e.: trickle down) policies

### DIFF
--- a/lib/hooks/policies/index.js
+++ b/lib/hooks/policies/index.js
@@ -380,9 +380,9 @@ module.exports = function(sails) {
 						}
 
 					}else{
-						//If policies are additive, 
-						//prepend controller-local '*' (if exists) and only if 
-						//prepend global '*' policy
+						//If policies are additive:
+						//1. prepend controller-local '*' (if exists) and only if `skipLocalWildcard` not defined
+						//2. prepend global '*' policy
 
 						if(!(actionPolicy.length && actionPolicy[0] === skipLocalWildcard)){
 							actionPolicy = (mapping[id]['*'] || []).concat(actionPolicy);


### PR DESCRIPTION
### Desc

As per #1643 this PR allows setting additive (or trickle down) policies. I.e.: policies that inherit from both (configurable) `global *` and `controller local *`. 

Additive policies are enabled by setting the following:
### Config

**config/policies.js**

```
  _config: {
    additive: true
  }
```
### Defaults

By default, the following inheritance takes place: 
- controller-policies inherit from `global *` before applying own policies
- action-policies inherit from both `global *` and `controller-local *`  (**in this order**) before applying own policies
### Overwrites

There needs to be an option to _overwrite_ policies so **not** to inherit policies. This is done as follows: 

**Controller policies**

Controller Policies can opt-out of inheriting from `global *` by defining `true` as their first policy (i.e.: allow all)

**Action policies**

Action Policies can: 
- opt-out of inheriting from `global *` as well as `controller-local *` by defining `true` as their first policy (i.e.: allow all)
- opt-out of inheriting from `controller-local *` (but still inherit  `global *`) by defining `_skiplocal*`  as their first policy
