### PR TITLE
Adding npm-Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "url": "http://github.com/balderdashy/sails/issues"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.10.0",
+    "npm": ">= 1.4.0"
   }
 }


### PR DESCRIPTION
In the Sails-beta you use "^" as indicator for version-selecting in packages.json.
Old npm Versions (like 1.2 running on openshift) can't handle this and quit npm install.
