### PR TITLE
support criteria on id field

### DIFF
--- a/lib/hooks/blueprints/actionUtil.js
+++ b/lib/hooks/blueprints/actionUtil.js
@@ -119,6 +119,8 @@ module.exports = {
     //  in the absence of `id`.)
     // See coercePK for reference (although be aware it is not currently in use)
 
+    // exclude criteria on id field
+    pk = _.isPlainObject(pk) ? undefined : pk;
     return pk;
   },
 


### PR DESCRIPTION
exclude criteria when parsing pk. criteria on id field with '>', '<', '>=', '<=' should work now (require to merge certain PRs on sails-mongo, https://github.com/balderdashy/sails-mongo/pull/154, https://github.com/balderdashy/sails-mongo/pull/153 ).
