### PR TITLE
Allow multiple config for single transport v0.9 Logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -72,19 +72,14 @@ module.exports = function(sails) {
         // if adapter option is set, ALSO write log output to an adapter
         if (!_.isUndefined(config.adapters)) {
             _.each(config.adapters, function(val, transport) {
-                if (typeof val.module !== 'undefined') {
-
-                    // The winston module MUST be exported to a variable of same name
-                    var module = require(val.module)[transport];
-
-                    // Make sure it was exported correctly
-                    if (module) {
-                        transports.push(
-                            new(module)(val)
-                        );
+                if (_.isArray(val)) {
+                    for (var i in val) {
+                        transports = insertTransport(transports, transport, val[i]);
                     }
-              }
-          });
+                } else {
+                    transports = insertTransport(transports, transport, val);
+                }
+            });
         }
 
         // Instantiate winston
@@ -137,6 +132,27 @@ module.exports = function(sails) {
                 }
             };
         }
+    }
+
+    /** 
+
+    Add value to transport
+
+    */
+    function insertTransport (transports, transport, val) {
+        if (typeof val.module !== 'undefined') {
+            // The winston module MUST be exported to a variable of same name
+            var module = require(val.module)[transport];
+
+            // Make sure it was exported correctly
+            if (module) {
+                transports.push(
+                    new(module)(val)
+                );
+            }
+        }
+
+        return transports;
     }
 
 


### PR DESCRIPTION
Allow Sails logger to accept array of values/configs for a single transport.

Sample use case:
DailyRotateFile transport needs to write to different files for different log levels.
