### PR TITLE
Socketio redis error

### DIFF
--- a/lib/hooks/sockets/configure.js
+++ b/lib/hooks/sockets/configure.js
@@ -151,7 +151,11 @@ module.exports = function (sails) {
 		}
 
 		if (socketConfig.onError) {
-			client.on('error', socketConfig.onError);
+			client.on('error', function connectionErrorListener(){
+				var args = Array.prototype.slice.call(arguments);
+				args.push(client);
+				socketConfig.onError.apply(this, args);
+			});
 		}
 
 		if (socketConfig.onReady) {


### PR DESCRIPTION
New PR against the right branch

Branched from the latest 0.9 tag which is 0.9.16

When using the redis adapter for Socket.io, there was no way to pass in a listener for on Error, which meant that the application just dies when you get an error back from Redis - such as losing connection. Yes, dying is probably the best bet bet its better to handle that gracefully rather than having a nasty process.on('uncaughtException') dealing with all errors, I'd rather deal with a redis error in my codebase.

This allows you to listen in on the ready event and the error event from Redis. The raw connection is also passed back to the error callback, so that you can get down and dirty with the connection itself if you need to, such as knowing when you've reconnected.
