### PR TITLE
Grunt-Hook: Fix #1872

### DIFF
--- a/lib/hooks/grunt/index.js
+++ b/lib/hooks/grunt/index.js
@@ -34,7 +34,7 @@ module.exports = function (sails) {
      * Fork Grunt child process
      *
      * @param {String} taskName - grunt task to run
-     * @param {Function} cb - optional, fires when the Grunt task has been started
+     * @param {Function} cb - optional, fires when the Grunt task has been started (development) or finished (production)
      */
     runTask: function (taskName, cb_afterTaskStarted) {
       cb_afterTaskStarted = cb_afterTaskStarted || function () {};
@@ -153,6 +153,11 @@ module.exports = function (sails) {
       child.on('exit', function (code, s) {
         if ( code !== 0 ) return sails.emit('hook:grunt:error');
         sails.emit('hook:grunt:done');
+        
+        // Fire finish after grunt is done in production
+        if(sails.config.environment === 'production'){
+          cb_afterTaskStarted();
+        }
       });
 
       // Since there's likely a watch task involved, and we may need
@@ -162,7 +167,9 @@ module.exports = function (sails) {
       sails.childProcesses.push(child);
 
       // Go ahead and get out of here, since Grunt might sit there backgrounded
-      cb_afterTaskStarted();
+      if(sails.config.environment === 'development'){
+         cb_afterTaskStarted();
+      }
     }
   };
 };


### PR DESCRIPTION
In production-mode: call cb() of Grunt-Hook only after grunt:prod finished.

(fixing for https://github.com/balderdashy/sails/issues/1872)
