### PR TITLE
updated i18n to 0.5.0 to fix #1878

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node-uuid": "~1.4.0",
     "ejs-locals": "~1.0.2",
     "glob": "~3.2.9",
-    "i18n": "~0.4.1",
+    "i18n": "~0.5.0",
     "sails-generate": "~0.10.2",
     "sails-build-dictionary": "~0.10.1",
     "grunt-cli": "~0.1.11",


### PR DESCRIPTION
I'd have added a unit test to prove that this fixed the `objectNotation` bug, ala #1878 but I couldn't work out how to add data to the locales being tested without also forking and patching the `sails-generate-backed` project.

I have run the tests against this change however and nothing broke, so at least it's no worse than it was.
