### PR TITLE
Changed sails.sockets.subscribers to return sockets instead of IDs.

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -279,12 +279,17 @@ module.exports = function(sails) {
     };
 
     /**
-     * Get the list of IDs of sockets subscribed to a room
+     * Get the list of sockets subscribed to a room
      * @param  {string} roomName The room to get subscribers of
-     * @return {array} An array of socket instances
+     * @param  {boolean} returnSockets If true, return socket instances rather than IDs.
+     * @return {array} An array of socket ID strings
      */
-    sails.sockets.subscribers = function(roomName) {
-      return sails.io.sockets.clients(roomName);
+    sails.sockets.subscribers = function(roomName, returnSockets) {
+      if (returnSockets) {
+        return sails.io.sockets.clients(roomName);
+      } else {
+        return _.pluck(sails.io.sockets.clients(roomName), 'id');
+      }
     };
 
     /**
@@ -558,7 +563,7 @@ module.exports = function(sails) {
       subscribers: function (id, context) {
         // For a single context, return just the socket subscribed to that context
         if (context) {
-          return sails.sockets.subscribers(this.room(id, context));
+          return sails.sockets.subscribers(this.room(id, context), true);
         }
         // Otherwise return the unique set of sockets subscribed to ALL contexts
         //
@@ -580,7 +585,7 @@ module.exports = function(sails) {
        * @api private
        */
       watchers: function() {
-        return sails.sockets.subscribers(this._classRoom());
+        return sails.sockets.subscribers(this._classRoom(), true);
       },
 
       /**


### PR DESCRIPTION
While building a Sails app, we ran into an odd issue where certain websockets weren't being subscribed to the correct rooms when new objects were created, which resulted in clients failing to receive a message when `publishDestroy` was called.

We eventually traced this issue back to what looks like a type mismatch: `subscribers` and `watchers` functions are both documented to return socket objects, but they returned IDs. As well, [the `introduce` function](#L1430) calls `subscribe` with the results of the `watchers()` function. `subscribe` expects a `request` or `socket` object as its first parameter, but was receiving a string. (This was preventing legacy clients from receiving events on models that they had been `introduce`d to.)

I managed to trace the original change back to [a commit in January](https://github.com/balderdashy/sails/commit/c019f26c1be2dfc85faf84484676bce657d6a2d8), but it doesn't appear that `sails.sockets.subscribers` is used anywhere else anymore.
