### PR TITLE
allow to use populate feature with custom route

### DIFF
--- a/lib/hooks/controllers/onRoute.js
+++ b/lib/hooks/controllers/onRoute.js
@@ -144,14 +144,32 @@ module.exports = function (sails) {
 			return;
 		}
 
-
 		// (if unspecified, default actionId to 'index'
 		actionId = actionId || 'index';
 
 		// Merge the target controller/action into our route options:
 		options.controller = controllerId;
 		options.action = actionId;
-		
+
+
+    // Determine the model connected to this controller either by:
+    // -> on the routes config
+    // -> on the controller
+    var modelId = options.model || controllerId;
+
+    // If the orm hook is enabled, it has already been loaded by this time,
+    // so just double-check to see if the attached model exists in `sails.models`.
+    if (sails.hooks.orm && sails.models && sails.models[modelId]) {
+
+      // If a model with matching identity exists,
+      // extend route options with the id of the model.
+      options.model = modelId;
+
+      var Model = sails.models[modelId];
+
+      // Mix in the known associations for this model to the route options.
+      options = _.merge({ associations: _.cloneDeep(Model.associations) }, options);
+    }
 
 		// 1. Bind the specified `action`
 		var subTarget = controller[actionId];


### PR DESCRIPTION
1. config custom route : { controller: 'User', action: 'customFind' }, then enable populate either by:
   - set `populate: true` on route config: { controller: 'User', action: 'customFind', populate: true }
   - use query param `populate=alias1,alias2,...,aliasn` within each request
2. use actionUtil.populateEach() in custom controller action
