### PR TITLE
Fixed Grunt hook when not in development or production environments.

### DIFF
--- a/lib/hooks/grunt/index.js
+++ b/lib/hooks/grunt/index.js
@@ -34,7 +34,7 @@ module.exports = function (sails) {
      * Fork Grunt child process
      *
      * @param {String} taskName - grunt task to run
-     * @param {Function} cb - optional, fires when the Grunt task has been started (development/test) or finished (production)
+     * @param {Function} cb - optional, fires when the Grunt task has been started (non-production) or finished (production)
      */
     runTask: function (taskName, cb_afterTaskStarted) {
       cb_afterTaskStarted = cb_afterTaskStarted || function () {};


### PR DESCRIPTION
For those Sails apps that don't just use `development` and `production` (i.e.: also `test` or something similar), commit https://github.com/balderdashy/sails/commit/307ed1b2217f13eb7d61e18c0e3e333e4347f6a3 breaks Grunt by causing it to hang indefinitely. This PR fixes that.
