### PR TITLE
Allow to set updateFiles in sails.config.i18n

### DIFF
--- a/lib/hooks/i18n/index.js
+++ b/lib/hooks/i18n/index.js
@@ -16,6 +16,15 @@ module.exports = function (sails) {
 
   return {
 
+    defaults: {
+			// i18n
+			i18n: {
+				locales: ['en', 'es'],
+				defaultLocale: 'en',
+				localesDirectory: '/config/locales'
+			}
+		},
+
     routes: {
 
       before: {
@@ -42,13 +51,12 @@ module.exports = function (sails) {
 
       // Try
       .run(function () {
-        i18n.configure({
-          locales: sails.config.i18n.locales,
-          directory: sails.config.appPath + sails.config.i18n.localesDirectory,
-          defaultLocale: sails.config.i18n.defaultLocale,
-          updateFiles: false,
-          extension: '.json'
-        });
+        i18n.configure(_.defaults(sails.config.i18n, {
+					cookie: null,
+					directory: sails.config.appPath + sails.config.i18n.localesDirectory,
+					updateFiles: false,
+					extension: '.json'
+				}));
       });
 
       // Finally


### PR DESCRIPTION
This is a port of https://github.com/balderdashy/sails/blob/b49873dc0d5afa8e0f296ea48bfe1fc838364393/lib/hooks/i18n/index.js

In the stable branch, updateFiles is set to false always (you can't set it in the i18n config file). As it defaults to false, it won't break anything (unless you set it to true and left it there without working - which is unlikely).

I tested it on 0.9.16 and works as expected. I'm not sure if the "defaults: {...}" is needed in the 0.9 branch.
