### PR TITLE
fix policy doesn't protected blueprint action in some cases

### DIFF
--- a/lib/hooks/blueprints/onRoute.js
+++ b/lib/hooks/blueprints/onRoute.js
@@ -98,6 +98,12 @@ module.exports = function (sails) {
         );
         return;
       }
+    } else if (sails.models && !sails.models[options.model]) {
+      sails.log.error(
+        blueprintActionID,
+          ':: Ignoring attempt to bind route (' + path + ') to unknown model (`'+options.model+'`).'
+      );
+      return;
     }
 
     // If associations weren't provided with the options, try and get them
@@ -131,7 +137,7 @@ module.exports = function (sails) {
       options.populate = sails.config.blueprints.populate;
     }
 
-		sails.router.bind(path, blueprint, verb, options);
+		sails.router.bind(path, { controller: options.model, action: blueprintActionID }, verb, options);
 
 		return;
 	}

--- a/lib/hooks/controllers/onRoute.js
+++ b/lib/hooks/controllers/onRoute.js
@@ -214,7 +214,7 @@ module.exports = function (sails) {
 			return;
 		}
 
-		sails.router.bind(path, blueprint, verb, options);
+		sails.router.bind(path, { model: options.model, blueprint: blueprintActionID }, verb, options);
 	}
 
 };


### PR DESCRIPTION

1. fix policy doesn't protected blueprint action with custom route option
2. fix policy doesn't protected custom blueprint action
3. fix sails fails to lift if using in-exist model in route config

https://github.com/balderdashy/sails/issues/1932