### PR TITLE
updating socket.io to 0.9.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "waterline": "~0.9.16",
     "sails-disk": "~0.9.0",
     "express": "3.4.0",
-    "socket.io": "0.9.14",
+    "socket.io": "0.9.17",
     "connect-redis": "1.4.5",
     "connect-mongo": "0.3.2",
     "async": "0.2.9",


### PR DESCRIPTION
fixes #1765. socket.io 0.9.17, among other things, brings in the surespot/channelfix patch which addresses a major redis memory leak. read the full changelog at https://github.com/Automattic/socket.io/blob/0.9.17/History.md
