### PR TITLE
Starting Node Inspector if available

### DIFF
--- a/bin/sails-debug.js
+++ b/bin/sails-debug.js
@@ -9,7 +9,7 @@ var Sails = require('../lib/app');
 var path = require('path');
 var Womb = require('child_process');
 var CaptainsLog = require('captains-log');
-
+var Fs = require('fs');
 
 /*
 
@@ -30,13 +30,30 @@ module.exports = function() {
     pathToSails = path.resolve(__dirname, './sails.js');
   }
 
-  console.log();
-  log.info('Running node-inspector on this app...');
-  log.info('If you don\'t know what to do next, type `help`');
-  log.info('Or check out the docs:');
-  log.info('http://nodejs.org/api/debugger.html');
-  console.log();
+  // If NodeInspector is available, use it
+  var pathToInspector = path.join(appPath, '/node_modules/node-inspector');
+  if (Fs.existsSync(pathToInspector)) {
+    console.log(Sails.port);
 
+    log.info('Node Inspector available. Starting it.');
+    var inspector = Womb.spawn('./node-inspector', [], {
+      cwd: path.join(appPath, '/node_modules/.bin')
+    });
+    inspector.stdout.on('data', function (data) {
+      log.info(data.toString());
+    });
+    inspector.stderr.on('err', function (err) {
+      log.error(data.toString());
+    });
+  } else {
+
+    console.log();
+    log.info('Running node-inspector on this app...');
+    log.info('If you don\'t know what to do next, type `help`');
+    log.info('Or check out the docs:');
+    log.info('http://nodejs.org/api/debugger.html');
+    console.log();
+  }
 
   log.info(('( to exit, type ' + '<CTRL>+<C>' + ' )').grey);
   console.log();


### PR DESCRIPTION
Hi,

   I am not sure if it has its place here or if it should be done in a more customised way (Like in Grunt or something) but I found it very handy to have `node-inspector` started alongside `sails debug`

   This patch is modifying `sails-debug` script to do just that but only if `node-inspector` is present in the dependencies.

   The caveat is that I wasn't sure how to access the configuration files in here, so the inspector is running with the default parameters.
   I would happy to make it configurable if you have an idea how.
   Via config file, sails.rc or command line options maybe?
