### PR TITLE
specify criteria on findOne blueprint

### DIFF
--- a/lib/hooks/blueprints/actions/findOne.js
+++ b/lib/hooks/blueprints/actions/findOne.js
@@ -25,8 +25,8 @@ module.exports = function findOneRecord (req, res) {
 
   var Model = actionUtil.parseModel(req);
   var pk = actionUtil.requirePk(req);
-
-  var query = Model.findOne(pk);
+  var criteria = actionUtil.parseCriteria(req);
+  var query = Model.findOne(pk).where(criteria);
   query = actionUtil.populateEach(query, req);
   query.exec(function found(err, matchingRecord) {
     if (err) return res.serverError(err);


### PR DESCRIPTION
- Added the option to specify criteria on findOne

I needed a way to check if the record being fetched is one that belongs to the authenticated user. After this PR, for request `/thread/123` I can set a where, of type or, recipient = req.sessions.user, author = req.session.user. This is useful as it allows you to have less queries, and more specifically decide if you want the record with specified ID.

For my specific problem, I'd rather have something like outgoing policies, to check if the data is allowed to be fetched. Either way, I think this functionality is pretty useful.
