### PR TITLE
Proposal to fix sails www --prod

### DIFF
--- a/bin/sails-www.js
+++ b/bin/sails-www.js
@@ -24,8 +24,7 @@ module.exports = function() {
 
   var wwwPath = nodepath.resolve(process.cwd(), './www'),
     GRUNT_TASK_NAME = 'build';
-
-  log.info('Compiling assets into standalone `www` directory with `grunt ' + GRUNT_TASK_NAME + '`...');
+    GRUNT_TASK_PROD_NAME = 'buildProd';
 
   var sails = Sails();
   sails.load(_.merge({}, rconf, {
@@ -36,13 +35,17 @@ module.exports = function() {
   }), function sailsReady(err) {
     if (err) return Err.fatal.failedToLoadSails(err);
 
+    var overrideGruntTask = (sails.config.environment == 'production' ? GRUNT_TASK_PROD_NAME : GRUNT_TASK_NAME)
+  
     // Run Grunt task
     var Grunt = __Grunt(sails);
-    Grunt.runTask(GRUNT_TASK_NAME);
+
+    log.info('Compiling assets into standalone `www` directory with `grunt ' + overrideGruntTask + '`...');
+    Grunt.runTask(overrideGruntTask);
 
     // Bind error event
     sails.on('hook:grunt:error', function(err) {
-      log.error('Error occured starting `grunt ' + GRUNT_TASK_NAME + '`');
+      log.error('Error occured starting `grunt ' + overrideGruntTask + '`');
       log.error('Please resolve any issues and try running `sails www` again.');
       log.error(err);
       process.exit(1);

--- a/test/integration/www.test.js
+++ b/test/integration/www.test.js
@@ -1,0 +1,127 @@
+var assert = require('assert');
+var fs = require('fs');
+var wrench = require('wrench');
+var request = require('request');
+var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
+
+// Make existsSync not crash on older versions of Node
+fs.existsSync = fs.existsSync || require('path').existsSync;
+
+describe('Starting sails server with lift', function() {
+	var sailsBin = './bin/sails.js';
+	var appName = 'testApp';
+	var sailsServer;
+
+	before(function() {
+		if (fs.existsSync(appName)) {
+			wrench.rmdirSyncRecursive(appName);
+		}
+	});
+
+	after(function() {
+		if (fs.existsSync(appName)) {
+			wrench.rmdirSyncRecursive(appName);
+		}
+	});
+
+	describe('in an empty directory', function() {
+
+		before(function() {
+			// Make empty folder and move into it
+			fs.mkdirSync('empty');
+			process.chdir('empty');
+			sailsBin = '.' + sailsBin;
+		});
+
+		after(function() {
+			// Delete empty folder and move out of it
+			process.chdir('../');
+			fs.rmdirSync('empty');
+			sailsBin = sailsBin.substr(1);
+		});
+
+	});
+
+	describe('in an sails app directory', function() {
+
+		it('should start server without error', function(done) {
+
+			exec(sailsBin + ' new ' + appName, function(err) {
+				if (err) done(new Error(err));
+
+				// Move into app directory
+				process.chdir(appName);
+				sailsBin = '.' + sailsBin;
+
+				sailsServer = spawn(sailsBin, ['www']);
+
+				sailsServer.stdout.on('data', function(data) {
+					var dataString = data + '';
+					assert(dataString.indexOf('error') === -1);
+					sailsServer.stdout.removeAllListeners('data');
+					sailsServer.kill();
+					// Move out of app directory
+					process.chdir('../');
+					done();
+				});
+			});
+		});
+
+	});
+
+	describe('with command line arguments', function() {
+		afterEach(function() {
+			sailsServer.stderr.removeAllListeners('data');
+			sailsServer.kill();
+			process.chdir('../');
+		});
+
+		it('--dev should execute grunt build', function(done) {
+
+			// Move into app directory
+			process.chdir(appName);
+
+			// Change environment to production in config file
+			fs.writeFileSync('config/application.js', 'module.exports = ' + JSON.stringify({
+				appName: 'Sails Application',
+				port: 1342,
+				environment: 'production',
+				log: {
+					level: 'info'
+				}
+			}));
+
+			sailsServer = spawn(sailsBin, ['www', '--dev']);
+
+			sailsServer.stdout.on('data', function(data) {
+				var dataString = data + '';
+				if (dataString.indexOf("`grunt build`") !== -1) {
+
+					done();
+				}
+			});
+		});
+
+		it('--prod should execute grunt buildProd', function(done) {
+
+			// Move into app directory
+			process.chdir(appName);
+
+			// Overrwrite session config file
+			// to set session adapter:null ( to prevent warning message from appearing on command line )
+			fs.writeFileSync('config/session.js', 'module.exports.session = { adapter: null }');
+
+			sailsServer = spawn(sailsBin, ['www', '--prod']);
+
+			sailsServer.stdout.on('data', function(data) {
+				var dataString = data + '';
+				if (dataString.indexOf("`grunt buildProd`") !== -1) {
+
+					done();
+				}
+			});
+		});
+
+	});
+});


### PR DESCRIPTION
As stated in here: https://github.com/balderdashy/sails/issues/1973, the command `sails www` wasn't working properly in production mode. This PR is a proposal to fix it.

The only thing I did is to, after Sails got all its configuration sorted, execute `grunt buildProd` instead of `grunt build` when the user override NODE_ENV or execute sails with `--prod` option (or use any kind of override for what matters)

`grunt buildProd` was already doing the job of minifying and concatenate so I guessed it was the target intended for it at first.

And then the control is on user hands as this grunt task can be easily tweaked.

Hope this correspond to the guidelines
