### PR TITLE
Send PATCH requests to the "update" blueprint.

### DIFF
--- a/lib/hooks/blueprints/index.js
+++ b/lib/hooks/blueprints/index.js
@@ -312,6 +312,7 @@ module.exports = function(sails) {
             _bindRoute(_getRoute('post %s'), 'create');
             _bindRoute(_getRoute('put %s/:id'), 'update');
             _bindRoute(_getRoute('post %s/:id'), 'update');
+            _bindRoute(_getRoute('patch %s/:id'), 'update');
             _bindRoute(_getRoute('delete %s/:id?'), 'destroy');
 
             // Bind "rest" blueprint/shadow routes based on known associations in our model's schema

--- a/lib/hooks/cors/index.js
+++ b/lib/hooks/cors/index.js
@@ -20,7 +20,7 @@ module.exports = function(sails) {
 			cors: {
 				origin: '*',
 				credentials: true,
-				methods: 'GET, POST, PUT, DELETE, OPTIONS, HEAD',
+				methods: 'GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD',
 				headers: 'content-type'
 			}
 		},


### PR DESCRIPTION
It makes it possible to deal with PATCH requests in blueprints, which is important to use [JSON PATCH](http://tools.ietf.org/html/rfc6902) and [JSON API](http://jsonapi.org/). It is linked to feature request #1268.