### PR TITLE
Mini: Updating package.json > devDependencies > microtime to ~0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "istanbul": "*",
     "wrench": "~1.5.1",
     "benchmark": "~1.0.0",
-    "microtime": "~0.5.1",
+    "microtime": "~0.6.0",
     "colors": "~0.6.2",
     "expect.js": "~0.2.0",
     "should": "~2.1.1",


### PR DESCRIPTION
The command `npm install` on `nodejs=v0.11.13` and `npm=v1.4.9` fails with error

``` javascript
10117 error microtime@0.5.1 install: `node-gyp rebuild`
10117 error Exit status 1
10118 error Failed at the microtime@0.5.1 install script.
10118 error This is most likely a problem with the microtime package,
10118 error not with npm itself.
10118 error Tell the author that this fails on your system:
10118 error     node-gyp rebuild
10118 error You can get their info via:
10118 error     npm owner ls microtime
10118 error There is likely additional logging output above.
10119 error System Darwin 13.3.0
10120 error command "/Users/me/.nvm/v0.11.13/bin/node" "/Users/me/.nvm/v0.11.13/bin/npm" "install"
10121 error cwd /Users/me/Downloads/sails-master
10122 error node -v v0.11.13
10123 error npm -v 1.4.9
10124 error code ELIFECYCLE
10125 verbose exit [ 1, true ]
```

Changing microtime's version to `0.6.0` works. I see all tests are green.
