### PR TITLE
Add missing require for async module

### DIFF
--- a/lib/hooks/blueprints/actions/add.js
+++ b/lib/hooks/blueprints/actions/add.js
@@ -4,6 +4,7 @@
 var util = require('util');
 var actionUtil = require('../actionUtil');
 var _ = require('lodash');
+var async = require('async');
 
 
 /**


### PR DESCRIPTION
Added missing require statement to bring in async module, `async.auto` is called below.

This is needed if the user decides not to allow the global async variable.
