### PR TITLE
Fix crash when using sessionless requests over WebSockets.

### DIFF
--- a/lib/hooks/sockets/lib/interpreter/saveSessionAndThen.js
+++ b/lib/hooks/sockets/lib/interpreter/saveSessionAndThen.js
@@ -15,12 +15,19 @@ module.exports = function saveSessionAndThen(req, sails, cb) {
 	return function saveSession () {
 		var ctx = this,
 			args = Array.prototype.slice.call(arguments);
-
-		req.session.save(function (err) {
+		var next = function (err) {
 			if (err) {
 				sails.log.error('Session could not be persisted:',err);
 			}
 			cb.apply(ctx,args);
-		});
+		};
+
+		// If we have a session on the request, save it
+		// Otherwise, process the callback on the next tick
+		if (req.session) {
+			req.session.save(next);
+		} else {
+			process.nextTick(next);
+		}
 	};
 };


### PR DESCRIPTION
When disabling sessions for individual requests, it's done by deleting
the session field from the request. (See
https://github.com/balderdashy/sails/issues/841).

Unfortunately, the REST-over-WebSocket code assumed that the session was
always there. This patch checks for the existence of req.session before
calling req.session.save.
