### PR TITLE
Added sails migrate to Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,4 +47,4 @@ The backlog consists of features which are not currently in the immediate-term r
  Support for multiple blueprint prefixes         | [@mnaughto](https://github.com/mnaughto) | https://github.com/balderdashy/sails/issues/2031
  SDPY protocol support (on top of http:// and ws://)  | [@mikermcneil](https://github.com/mikermcneil)  | https://github.com/balderdashy/sails/issues/80
  Build an alternative sockets hook which uses Primus | [@alejandroiglesias](https://github.com/alejandroiglesias) | https://github.com/balderdashy/sails/issues/945
-
+ Have a `sails migrate` or `sails create-db` command | [@globegitter](https://github.com/Globegitter) | For production environments it would be nice to have a save command that creates the db automatically for you


### PR DESCRIPTION
I really think that the process of getting to a production environment, especially when using MySQL or PostgreSQL can be improved. I love auto-migrations on sails lift and I can also understand that they are not run during production, but I think we should implement a separate command that just this whole process more automated while keeping it save at the same time.
This is still more than open for discussion, in fact I haven't fully thought through of all the use cases.
The most simple would be just having a `create-db` command which just runs auto-migrations on a fresh production system. But that would not support any changes to the model, so I think a `sails migrate` command would be preferable but I am not sure yet how that would work when you run this to try and update a model.
So any feedback, if that is even useful, or if there is a better way to do it and how it should be done is appreciated.
