### PR TITLE
Fix grunt launching when it's a peer dep

### DIFF
--- a/lib/hooks/grunt/grunt-wrapper.js
+++ b/lib/hooks/grunt/grunt-wrapper.js
@@ -1,0 +1,10 @@
+/**
+ * A hack to exec grunt without knowing exactly where it is.
+ *
+ * grunt-cli could be installed as a peer to sails, so we don't know
+ * where its bin script might be. But require can find it. We have this thin
+ * wrapper to be a script we can exec, and it will execute the grunt-cli,
+ * wherever it may be installed.
+ */
+
+require('grunt-cli/bin/grunt');

--- a/lib/hooks/grunt/index.js
+++ b/lib/hooks/grunt/index.js
@@ -54,7 +54,7 @@ module.exports = function (sails) {
       var child = ChildProcess.fork(
 
         // cwd for child process
-        path.join(pathToSails,'node_modules/grunt-cli/bin/grunt'),
+        path.join(__dirname, 'grunt-wrapper.js'),
 
         // cmd args+opts for child process
         [


### PR DESCRIPTION
There are times where someone may have grunt-cli installed as a peer
to sails. In those cases, the grunt-cli bin script isn't where we
thought it would be.

This patch uses a thin wrapper around grunt-cli, so we can exec it no
matter where it was actually installed. It just needs to be in the path
where require() can find it.
