### PR TITLE
Use 'www' folder if is available in production

### DIFF
--- a/lib/hooks/http/index.js
+++ b/lib/hooks/http/index.js
@@ -2,10 +2,10 @@
  * Module dependencies.
  */
 
-var path = require('path');
-var _ = require('lodash');
+var path    = require('path');
+var _       = require('lodash');
 var express = require('express');
-
+var fs      = require ('fs');
 
 module.exports = function(sails) {
 
@@ -44,7 +44,7 @@ module.exports = function(sails) {
         //  • an absolute path
         //  • a relative path from the app root (sails.config.appPath)
         paths: {
-          public: '.tmp/public'
+          public: config.environment === 'production' && fs.existsSync('www') ? 'www' : '.tmp/public'
         },
 
 


### PR DESCRIPTION
I would like know the opinion about this.

Instead of define again a gunt task to copy the files in '.tmp/folder', use www/ folder with static assets compiled.

.cc @davidrivera