### PR TITLE
Fix ect including path

### DIFF
--- a/lib/hooks/views/consolidate.js
+++ b/lib/hooks/views/consolidate.js
@@ -677,7 +677,10 @@ module.exports = function(sailsAppPath) {
     var engine = requires.ect;
     if (!engine) {
       var ECT = require(sailsAppPath + '/ect');
-      engine = requires.ect = new ECT();
+      engine = requires.ect = new ECT({
+        root: sailsAppPath + "/../views",
+        ext: ".ect"
+      });
     }
     engine.configure({ cache: options.cache });
     engine.render(path, options, fn);


### PR DESCRIPTION
When using the ECT, trying to use the `<% extend 'layout' %>` (extends)
Single page designate the absolute path, but (include|extend) is designate the relative path(and wrong!)
Maybe, This same problem as issue #2223 

ECT module was wrapping on `consolidate.js` and,  You can designate base path.
But couldn't rewite from app side.
And fix it.
