### PR TITLE
Changed parameter for maxAge configuration

### DIFF
--- a/lib/hooks/http/middleware/defaults.js
+++ b/lib/hooks/http/middleware/defaults.js
@@ -24,7 +24,7 @@ module.exports = function(sails, app) {
     // (By default, all explicit+shadow routes take precedence over flat files)
     www: (function() {
       var flatFileMiddleware = express['static'](sails.config.paths['public'], {
-        maxAge: sails.config.cache.maxAge
+        maxAge: sails.config.http.cache
       });
 
       // Make some MIME type exceptions for Google fonts


### PR DESCRIPTION
The maxAge parameter should be retrieved from the
sails.config.http.cache variable according to documentation.
