### PR TITLE
Redis down fix

### DIFF
--- a/lib/hooks/sockets/lib/loadSocketIO.js
+++ b/lib/hooks/sockets/lib/loadSocketIO.js
@@ -159,19 +159,17 @@ module.exports = function (sails) {
 		// until it comes back
 		 
 		client.on('ready', function() {
-			sails.log.debug('[OK] Redis ' + id + ' is up. Connections: ', client.connections);
+			sails.log.debug('RedisClient::Events[ready]: [OK] Redis "' + id + '" is up. Connections: ', client.connections);
 		});
 
 		client.on('end', function() {
-		  sails.log.debug(id + ' Redis Client Connected:', client.connected);
+		  sails.log.debug('RedisClient::Events[end]: "' + id + '" , Connected:', client.connected);
 		});
 
 		client.on('error', function (err) {
-			sails.log.error('Redis client error');
+			sails.log.error('RedisClient::Events[error]: "' + id + '" , ' + err);
 		    if (/ECONNREFUSED/g.test(err)) {
-		        sails.log.error('Waiting for ' + id + ' redis. Connections:', client.connections);
-		    } else {
-		        sails.log.error('Redis ' + id + ' error event - ' + client.host + ":" + client.port + " - " + err);
+		        sails.log.error('Waiting for "' + id + '" redis client to come back online. Connections:', client.connections);
 		    }
 		});
 


### PR DESCRIPTION
This is related to the issue I filed earlier today: https://github.com/balderdashy/sails/issues/2276

If I set the session and socket stores (or one of them) to use Redis as the adapter, and Redis goes down (for whatever reason), sails has an un-handled exception and crashes. It's actually really easy to fix this and make Sails send a 500 while Redis is down, and then when it comes back up, just re-connect.

Steps to reproduce current bug:
1) Make sure you have configured Redis as the session store (and the socket store)
2) sails lift (while redis is running)
3) go to a page on your app, or any route that works - it works
4) now shutdown redis
5) sails has crashed

I ran the tests, and everything seems to work.

Thanks!
