### PR TITLE
Add a config variable to tell Sails if it should run the prod grunt task...

### DIFF
--- a/lib/hooks/grunt/index.js
+++ b/lib/hooks/grunt/index.js
@@ -21,9 +21,15 @@ module.exports = function (sails) {
 
       sails.log.verbose('Loading app Gruntfile...');
 
-      // Start task depending on environment
-      if(sails.config.environment === 'production'){
+      /* Start task depending on environment
+       * Run the prod task by default when Sails is running in a 'production' environment
+       * If disableProductionBuild is set to true in config/local.js, then do not run this task
+       */
+      if(sails.config.environment === 'production' && !sails.config.disableProductionBuild) {
+        sails.log.verbose("Running 'prod' Grunt task once server is lifted...");
         return this.runTask('prod', cb);
+      } else if(sails.config.disableProductionBuild) {
+        sails.log.verbose("Skipping 'prod' Grunt task because disableProductionBuild is set to 'true'...");
       }
 
       this.runTask('default', cb);

--- a/test/integration/lift.test.js
+++ b/test/integration/lift.test.js
@@ -160,5 +160,41 @@ describe('Starting sails server with lift', function() {
 				}
 			});
 		});
+
+		it("--prod with disableProductionBuild not defined should execute grunt prod", function(done) {
+
+			// Move into app directory
+			process.chdir(appName);
+
+			sailsServer = spawn(sailsBin, ['lift', '--prod', '--verbose', '--port=1342']);
+
+			sailsServer.stdout.on('data', function(data) {
+				var dataString = data + '';
+				if (dataString.indexOf("Running 'prod' Grunt task once server is lifted") !== -1) {
+
+					done();
+				}
+			});
+		});
+
+		it("--prod with disableProductionBuild set to 'true' should not execute grunt prod", function(done) {
+
+			// Move into app directory
+			process.chdir(appName);
+
+			// Overrwrite local config file
+			// to set disableProductionBuild true ( to prevent Sails from running grunt tasks )
+			fs.writeFileSync('config/local.js', 'module.exports = { disableProductionBuild: true }');
+
+			sailsServer = spawn(sailsBin, ['lift', '--prod', '--verbose', '--port=1342']);
+
+			sailsServer.stdout.on('data', function(data) {
+				var dataString = data + '';
+				if (dataString.indexOf("Skipping 'prod' Grunt task because disableProductionBuild is set to 'true'") !== -1) {
+
+					done();
+				}
+			});
+		});
 	});
 });


### PR DESCRIPTION
... when lifted in production mode. Fixes #2270 

In `config/local.js`, we could add the following snippet which would come from the generator:

```
/***************************************************************************
    * In production, Sails will run the 'prod' grunt task when the            *
    * server is lifted.                                                       *
    *                                                                         *
    * If you prefer to build your assets before lifting your server,          *
    * then set disableProductionBuild to true.                                *
    ***************************************************************************/
   // disableProductionBuild: true
```

Please let me know if there are any comments/concerns