### PR TITLE
Upgrade express to close security vulnerabilities

### DIFF
--- a/lib/hooks/csrf/index.js
+++ b/lib/hooks/csrf/index.js
@@ -69,26 +69,33 @@ module.exports = function(sails) {
           if (sails.config.csrf.protectionEnabled) {
             var connect = require('express/node_modules/connect');
 
-            return connect.csrf()(req, res, function(err) {
+            try {
+              return connect.csrf()(req, res, function() {
+                if (util.isSameOrigin(req) || allowCrossOriginCSRF) {
+                  res.locals._csrf = req.csrfToken();
+                } else {
+                  res.locals._csrf = null;
+                }
+
+                next();
+              });
+            } catch(err) {
+              // Only attempt to handle invalid csrf tokens
+              if (err.message != 'invalid csrf token') throw err;
 
               var isRouteDisabled  = sails.config.csrf.routesDisabled.split(',').map(trim).indexOf(req.path) > -1;
 
-              if (util.isSameOrigin(req) || allowCrossOriginCSRF) {
-                res.locals._csrf = req.csrfToken();
+              if (isRouteDisabled) {
+                return next();
               } else {
-                res.locals._csrf = null;
-              }
-              if (err && !isRouteDisabled) {
                 // Return an Access-Control-Allow-Origin header in case this is a xdomain request
                 if (req.headers.origin) {
                   res.set('Access-Control-Allow-Origin', req.headers.origin);
                   res.set('Access-Control-Allow-Credentials', true);
                 }
                 return res.forbidden("CSRF mismatch");
-              } else {
-                return next();
               }
-            });
+            }
           }
 
           // Always ok

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "express": "3.4.3",
+    "express": "3.16.0",
     "waterline": "~0.10.9",
     "rc": "~0.5.0",
     "sails-stringfile": "~0.3.0",

--- a/test/integration/hook.cors_csrf.test.js
+++ b/test/integration/hook.cors_csrf.test.js
@@ -85,7 +85,7 @@ describe('CORS and CSRF ::', function() {
           }, function(err, response) {
             if (err) return done(new Error(err));
             assert.equal(response.statusCode, 200);
-            assert.equal(response.body, "GET,POST,PUT,HEAD,DELETE,TRACE,COPY,LOCK,MKCOL,MOVE,PROPFIND,PROPPATCH,UNLOCK,REPORT,MKACTIVITY,CHECKOUT,MERGE,M-SEARCH,NOTIFY,SUBSCRIBE,UNSUBSCRIBE,PATCH");
+            assert.equal(response.body, "GET,POST,PUT,HEAD,DELETE,TRACE,COPY,LOCK,MKCOL,MOVE,PURGE,PROPFIND,PROPPATCH,UNLOCK,REPORT,MKACTIVITY,CHECKOUT,MERGE,M-SEARCH,NOTIFY,SUBSCRIBE,UNSUBSCRIBE,PATCH,SEARCH,CONNECT");
             done();
           });
 
@@ -694,7 +694,7 @@ describe('CORS and CSRF ::', function() {
       it("a CSRF token should be present in view locals", function(done) {
         httpHelper.testRoute("get", 'viewtest/csrf', function (err, response) {
           if (err) return done(new Error(err));
-          assert(response.body.match(/csrf=.+=/), response.body);
+          assert(response.body.match(/csrf=.{36}(?!.)/), response.body);
           done();
         });
       });
@@ -858,7 +858,7 @@ describe('CORS and CSRF ::', function() {
               }
             }, function (err, response) {
             if (err) return done(new Error(err));
-            assert(response.body.match(/csrf=.+=/));
+            assert(response.body.match(/csrf=.{36}(?!.)/));
             done();
           });
         });
@@ -895,7 +895,7 @@ describe('CORS and CSRF ::', function() {
               }
             }, function (err, response) {
             if (err) return done(new Error(err));
-            assert(response.body.match(/csrf=.+=/));
+            assert(response.body.match(/csrf=.{36}(?!.)/));
             done();
           });
         });
@@ -962,7 +962,7 @@ describe('CORS and CSRF ::', function() {
               }
             }, function (err, response) {
             if (err) return done(new Error(err));
-            assert(response.body.match(/csrf=.+=/));
+            assert(response.body.match(/csrf=.{36}(?!.)/));
             done();
           });
         });
@@ -997,7 +997,7 @@ describe('CORS and CSRF ::', function() {
               }
             }, function (err, response) {
             if (err) return done(new Error(err));
-            assert(response.body.match(/csrf=.+=/));
+            assert(response.body.match(/csrf=.{36}(?!.)/));
             done();
           });
         });


### PR DESCRIPTION
Related issue: https://github.com/balderdashy/sails/issues/2070

Express 3.16.0 made some changes to its csrf logic and it now uses https://github.com/expressjs/csurf, so I had to update the Sails csrf hook to reflect those changes. The biggest change is that the express csrf() call actually throws a 403 error for invalid tokens instead of just returning the error like it used to. So I updated the hook to catch that error and then handle it the same from there.

I also updated the tests as needed, and they all pass.

Just let me know if this change should be made in `stable` instead of `master`.
