### PR TITLE
custom view extensions

### DIFF
--- a/lib/hooks/views/configure.js
+++ b/lib/hooks/views/configure.js
@@ -23,13 +23,16 @@ module.exports = function configure ( sails ) {
 		sails.config.views.engine = sails.config.viewEngine;
 	}
 
-	// Normalize view engine config
+	// Normalize view engine config and allow defining a custom extension
 	if (typeof sails.config.views.engine === 'string') {
-		var viewExt = sails.config.views.engine;
+		var viewExt = sails.config.views.extension || sails.config.views.engine;
 		sails.config.views.engine = {
+            name: sails.config.views.engine,
 			ext: viewExt
 		};
 	}
+
+    var engineName = sails.config.views.engine.name || sails.config.views.engine.ext;
 
 	// Ensure valid config
 	if (! (sails.config.views.engine && sails.config.views.engine.ext) ) {
@@ -56,24 +59,24 @@ module.exports = function configure ( sails ) {
 		);
 
 		try {
-			fn = consolidate(appDependenciesPath)[sails.config.views.engine.ext];
+			fn = consolidate(appDependenciesPath)[engineName];
 
 			if ( !_.isFunction(fn) ) {
-				sails.log.error(util.format('Invalid view engine (%s)-- are you sure it supports `consolidate`?', sails.config.views.engine.ext));
+				sails.log.error(util.format('Invalid view engine (%s)-- are you sure it supports `consolidate`?', engineName));
 				throw new Error();
 			}
 		}
 		catch (e) {
-			sails.log.error('Your configured server-side view engine (' + sails.config.views.engine.ext + ') could not be found.');
+			sails.log.error('Your configured server-side view engine (' + engineName + ') could not be found.');
 			sails.log.error('Usually, this just means you need to install a dependency.');
-			sails.log.error('To install ' + sails.config.views.engine.ext + ', run:  `npm install ' + sails.config.views.engine.ext + ' --save`');
+			sails.log.error('To install ' + engineName + ', run:  `npm install ' + engineName + ' --save`');
 			sails.log.error('Otherwise, please change your `engine` configuration in config/views.js.');
 			throw e;
 		}
 
 		// Save reference to view rendering function
 		sails.config.views.engine.fn = fn;
-		sails.log.silly('Configured view engine, `' + sails.config.views.engine.ext + '`');
+		sails.log.silly('Configured view engine, `' + engineName + '`');
 	}
 
 
@@ -91,10 +94,9 @@ module.exports = function configure ( sails ) {
 		sails.config.views.layout = 'layout.' + sails.config.views.engine.ext;
 	}
 
-	if ( sails.config.views.engine.ext !== 'ejs' &&
-		sails.config.views.layout ) {
+	if ( engineName !== 'ejs' && sails.config.views.layout ) {
 		sails.log.warn('Sails\' built-in layout support only works with the `ejs` view engine.');
-		sails.log.warn('You\'re using `'+ sails.config.views.engine.ext +'`.');
+		sails.log.warn('You\'re using `'+ engineName +'`.');
 		sails.log.warn('Ignoring `sails.config.views.layout`...');
 	}
 };


### PR DESCRIPTION
Adds the 'sails.config.views.extension' config property that allows for a custom view file extension easily
