### PR TITLE
Bind controller to action

### DIFF
--- a/lib/hooks/controllers/index.js
+++ b/lib/hooks/controllers/index.js
@@ -105,7 +105,7 @@ module.exports = function(sails) {
 
 						// Otherwise mix it in (this will override CRUD blueprints from above)
             action._middlewareType = 'ACTION: '+controllerId+'/'+actionId;
-						self.middleware[controllerId][actionId] = action;
+						self.middleware[controllerId][actionId] = action.bind(controller);
             self.explicitActions[controllerId] = self.explicitActions[controllerId] || {};
             self.explicitActions[controllerId][actionId] = true;
 


### PR DESCRIPTION
The reason is - using "this" keyword in controllers actions.
Here is full description with use case http://stackoverflow.com/questions/26398638/sailsjs-controller-context
