### PR TITLE
Ignore parse the non-json request

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -320,9 +320,15 @@ function qsParser(req,res,next) {
 }
 // Extremely simple body parser (`req.body`)
 function bodyParser (req, res, next) {
-  var bodyBuffer='';
-  var parsedBody={};
+  var bodyBuffer = '';
+  var parsedBody = {};
   if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'DELETE'){
+    req.body = _.merge(req.body, parsedBody);
+    return next();
+  }
+
+  var contentType = req.headers['content-type'] || '';
+  if (contentType.indexOf('application/json') === -1) {
     req.body = _.merge(req.body, parsedBody);
     return next();
   }


### PR DESCRIPTION
The bodyParser will eat the application/xml type post.