### PR TITLE
Removed 'rc' from anchor version again

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "include-all": "~0.1.3",
     "skipper": "~0.5.3",
     "merge-defaults": "~0.1.0",
-    "anchor": "~0.10.0-rc",
+    "anchor": "~0.10.0",
     "mock-req": "0.1.0",
     "mock-res": "0.1.0",
     "semver": "~2.2.1",


### PR DESCRIPTION
Somehow the branches managed to get messed up on this PR: https://github.com/balderdashy/sails/pull/2110, so something got pulled in wrong. This reverts that and I will send another PR adding sails migrate again.
Sorry about that.
