### PR TITLE
Fix a bug when using 'where' with a datetime in Blueprints

### DIFF
--- a/lib/hooks/blueprints/actionUtil.js
+++ b/lib/hooks/blueprints/actionUtil.js
@@ -2,9 +2,10 @@
  * Module dependencies
  */
 
-var _ = require('lodash'),
-  mergeDefaults = require('merge-defaults'),
-  util = require('util');
+var _             = require('lodash'),
+    mergeDefaults = require('merge-defaults'),
+    util          = require('util'),
+    sailsUtil     = require('sails-util');
 
 
 // Parameter used for jsonp callback is constant, as far as
@@ -179,7 +180,7 @@ module.exports = {
 
     // If `where` parameter is a string, try to interpret it as JSON
     if (_.isString(where)) {
-      where = tryToParseJSON(where);
+      where = sailsUtil.tolerantParse( where, dataReviver );
     }
 
     // If `where` has not been specified, but other unbound parameter variables
@@ -300,22 +301,20 @@ module.exports = {
 };
 
 
+function dataReviver(key, value) {
+  
+  if (typeof value === 'string') {
+    
+    if( value.length === 0 ) {
+      
+      return null;
+    } else {
+      var a = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
 
-
-
-
-// TODO:
-//
-// Replace the following helper with the version in sails.util:
-
-// Attempt to parse JSON
-// If the parse fails, return the error object
-// If JSON is falsey, return null
-// (this is so that it will be ignored if not specified)
-function tryToParseJSON (json) {
-  if (!_.isString(json)) return null;
-  try {
-    return JSON.parse(json);
+      if ( a ) {
+        return new Date( Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4], +a[5], +a[6]) );
+      }
+    }
   }
-  catch (e) { return e; }
+  return value;
 }


### PR DESCRIPTION
Hi!
Values are not parse well when you use blueprint,
if you run the `npm test` of an adapter, you will have greaterThan and lessThan tests on Dates. Those tests generate data and when you run the adapted test for blueprints:
`http://localhost:1337/api/user2/?where=%7B%22type%22%3A%22lessThanOrEqual%20dates%20test%22%2C%22dob%22%3A%7B%22%3C%3D%22%3A%222013-11-01T23%3A00%3A00.000Z%22%7D%7D`
from 
```
        it('should return records with lessThanOrEqual key when searching dates', function(done) {
          Queryable.User.find({ type: testName, dob: { lessThanOrEqual: new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
            assert(!err);
            assert(Array.isArray(users));
            assert(users.length === 2);
            assert(users[1].first_name === 'lessThanOrEqual_dates_user1');
            done();
          });
        });

        it('should return records with symbolic usage <= usage when searching dates', function(done) {
          Queryable.User.find({ type: testName, dob: { '<=': new Date(2013, 10, 2) }}).sort('first_name').exec(function(err, users) {
            assert(!err);
            assert(Array.isArray(users));
            assert(users.length === 2);
            assert(users[1].first_name === 'lessThanOrEqual_dates_user1');
            done();
          });
        });
```
The result is an Array of ONE model ( TWO expected ). (with sails-mysql and maybe other)

This fix is not THE answer to fix this, but it's work.

And replace tryParse by sails-util.tolerantParse.