### PR TITLE
Add multiple sort support on blueprints

### DIFF
--- a/lib/hooks/blueprints/actionUtil.js
+++ b/lib/hooks/blueprints/actionUtil.js
@@ -274,7 +274,18 @@ module.exports = {
    * @param  {Request} req
    */
   parseSort: function (req) {
-    return req.param('sort') || req.options.sort || undefined;
+    var sort = req.param('sort');
+
+    if( _.isString( sort ) ) {
+
+      try {
+        sort = JSON.parse( sort );
+      } catch( e ) {
+        // we just need to know if we can parse it, so the Exception will be ignored
+      }
+    }
+
+    return sort || req.options.sort || undefined;
   },
 
   /**

--- a/lib/hooks/blueprints/actionUtil.js
+++ b/lib/hooks/blueprints/actionUtil.js
@@ -277,7 +277,6 @@ module.exports = {
     var sort = req.param('sort');
 
     if( _.isString( sort ) ) {
-
       try {
         sort = JSON.parse( sort );
       } catch( e ) {


### PR DESCRIPTION
Hi!

This PR add multiple sort support on blueprints

Basic usage still working:  `?sort=foo ASC`
but add JSON support like `?sort={foo: 'ASC', bar: 'DESC'}` (basically same parameters than Waterline)

As referred https://github.com/balderdashy/sails/issues/2449