### PR TITLE
pull apart actionUtil.populateEach to support reuse outside requests

### DIFF
--- a/lib/hooks/blueprints/actionUtil.js
+++ b/lib/hooks/blueprints/actionUtil.js
@@ -18,18 +18,19 @@ var JSONP_CALLBACK_PARAM = 'callback';
  *
  * @type {Object}
  */
-module.exports = {
+var actionUtil = {
 
   /**
-   * Given a Waterline query, populate the appropriate/specified
-   * association attributes and return it so it can be chained
-   * further ( i.e. so you can .exec() it )
+   * Given a Waterline query and an express request, populate
+   * the appropriate/specified association attributes and 
+   * return it so it can be chained further ( i.e. so you can 
+   * .exec() it )
    *
    * @param  {Query} query         [waterline query object]
    * @param  {Request} req
    * @return {Query}
    */
-  populateEach: function ( query, req ) {
+  populateRequest: function(query, req) {
     var DEFAULT_POPULATE_LIMIT = sails.config.blueprints.defaultLimit || 30;
     var _options = req.options;
     var aliasFilter = req.param('populate');
@@ -45,8 +46,9 @@ module.exports = {
       aliasFilter = (aliasFilter) ? aliasFilter.split(',') : [];
     }
 
-    return _(_options.associations).reduce(function populateEachAssociation (query, association) {
+    var associations = [];
 
+    _.each(_options.associations, function(association) {
       // If an alias filter was provided, override the blueprint config.
       if (aliasFilter) {
         shouldPopulate = _.contains(aliasFilter, association.alias);
@@ -61,14 +63,52 @@ module.exports = {
       // (true to populate, false to not)
       if (shouldPopulate) {
         var populationLimit =
-          _options['populate_'+association.alias+'_limit'] ||
+          _options['populate_' + association.alias + '_limit'] ||
           _options.populate_limit ||
           _options.limit ||
           DEFAULT_POPULATE_LIMIT;
 
-        return query.populate(association.alias, {limit: populationLimit});
+        associations.push({
+          alias: association.alias,
+          limit: populationLimit
+        });
       }
-      else return query;
+    });
+
+    return actionUtil.populateQuery(query, associations);
+  },
+
+  /**
+   * Given a Waterline query and Waterline model, populate the 
+   * appropriate/specified association attributes and return it
+   * so it can be chained further ( i.e. so you can .exec() it )
+   *
+   * @param  {Query} query         [waterline query object]
+   * @param  {Model} model         [waterline model object]
+   * @return {Query}
+   */
+  populateModel: function(query, model) {
+    return actionUtil.populateQuery(query, model.associations);
+  },
+  
+
+ /**
+  * Given a Waterline query, populate the appropriate/specified
+  * association attributes and return it so it can be chained
+  * further ( i.e. so you can .exec() it )
+  *
+  * @param  {Query} query         [waterline query object]
+  * @param  {Array} associations  [array of objects with an alias
+  *                                and (optional) limit key]
+  * @return {Query}
+  */ 
+  populateQuery: function(query, associations) {
+    var DEFAULT_POPULATE_LIMIT = sails.config.blueprints.defaultLimit || 30;
+
+    return _.reduce(associations, function(query, association) {
+      return query.populate(association.alias, {
+        limit: association.limit || DEFAULT_POPULATE_LIMIT
+      });
     }, query);
   },
 
@@ -319,3 +359,5 @@ function tryToParseJSON (json) {
   }
   catch (e) { return e; }
 }
+
+module.exports = actionUtil;

--- a/lib/hooks/blueprints/actions/add.js
+++ b/lib/hooks/blueprints/actions/add.js
@@ -174,7 +174,7 @@ module.exports = function addToCollection (req, res) {
       }
 
       // Finally, look up the parent record again and populate the relevant collection.
-      // TODO: populateEach
+      // TODO: populateRequest
       Model.findOne(parentPk).populate(relation).exec(function(err, matchingRecord) {
         if (err) return res.serverError(err);
         if (!matchingRecord) return res.serverError();

--- a/lib/hooks/blueprints/actions/destroy.js
+++ b/lib/hooks/blueprints/actions/destroy.js
@@ -24,7 +24,7 @@ module.exports = function destroyOneRecord (req, res) {
   var pk = actionUtil.requirePk(req);
 
   var query = Model.findOne(pk);
-  query = actionUtil.populateEach(query, req);
+  query = actionUtil.populateRequest(query, req);
   query.exec(function foundRecord (err, record) {
     if (err) return res.serverError(err);
     if(!record) return res.notFound('No record found with the specified `id`.');

--- a/lib/hooks/blueprints/actions/find.js
+++ b/lib/hooks/blueprints/actions/find.js
@@ -42,8 +42,7 @@ module.exports = function findRecords (req, res) {
   .limit( actionUtil.parseLimit(req) )
   .skip( actionUtil.parseSkip(req) )
   .sort( actionUtil.parseSort(req) );
-  // TODO: .populateEach(req.options);
-  query = actionUtil.populateEach(query, req);
+  query = actionUtil.populateRequest(query, req);
   query.exec(function found(err, matchingRecords) {
     if (err) return res.serverError(err);
 

--- a/lib/hooks/blueprints/actions/findOne.js
+++ b/lib/hooks/blueprints/actions/findOne.js
@@ -24,7 +24,7 @@ module.exports = function findOneRecord (req, res) {
   var pk = actionUtil.requirePk(req);
 
   var query = Model.findOne(pk);
-  query = actionUtil.populateEach(query, req);
+  query = actionUtil.populateRequest(query, req);
   query.exec(function found(err, matchingRecord) {
     if (err) return res.serverError(err);
     if(!matchingRecord) return res.notFound('No record found with the specified `id`.');

--- a/lib/hooks/blueprints/actions/remove.js
+++ b/lib/hooks/blueprints/actions/remove.js
@@ -49,7 +49,7 @@ module.exports = function remove(req, res) {
 
       Model.findOne(parentPk)
       .populate(relation)
-      // TODO: use populateEach util instead
+      // TODO: use populateRequest util instead
       .exec(function found(err, parentRecord) {
         if (err) return res.serverError(err);
         if (!parentRecord) return res.serverError();

--- a/lib/hooks/blueprints/actions/update.js
+++ b/lib/hooks/blueprints/actions/update.js
@@ -79,7 +79,7 @@ module.exports = function updateOneRecord (req, res) {
       //  included by default to provide a better interface for integrating
       //  front-end developers.)
       var Q = Model.findOne(updatedRecord[Model.primaryKey]);
-      Q = actionUtil.populateEach(Q, req);
+      Q = actionUtil.populateRequest(Q, req);
       Q.exec(function foundAgain(err, populatedRecord) {
         if (err) return res.serverError(err);
         if (!populatedRecord) return res.serverError('Could not find record after updating!');


### PR DESCRIPTION
Turns actionUtil.populateEach into 3 different functions that craves the way towards more reusable functions.

Our use case:

In certain specific scenarios [we want to publish actions](https://stackoverflow.com/questions/27254587/sails-publishupdate-system-does-not-propagate-to-associations) (publishUpdate et al.) to associated models (eg: User has Pets, when a pet changes, publish User update). We want to auto populate the associated models but where unable to use populateEach due its dependence on a `req` object. 

EDIT: next step would be exposing those helper function to userland somehow.