### PR TITLE
catch undefined child pk in blueprints/remove

### DIFF
--- a/lib/hooks/blueprints/actions/remove.js
+++ b/lib/hooks/blueprints/actions/remove.js
@@ -37,6 +37,10 @@ module.exports = function remove(req, res) {
   // from the aliased collection
   var childPk = actionUtil.parsePk(req);
 
+  if(_.isUndefined(childPk)) {
+    return res.serverError('Missing required child PK.');
+  }
+
   Model
   .findOne(parentPk).exec(function found(err, parentRecord) {
     if (err) return res.serverError(err);


### PR DESCRIPTION
If you don't specify a child PK in the remove call (to remove an assocation), sails will crash. Example:

    io.socket.delete('/user/1/pets/') // note the missing pet ID

Will result in:

```/usr/local/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/remove.js:205
  if(key.toString() !== '[object Object]') validAssociation = true;
         ^
TypeError: Cannot call method 'toString' of undefined
    at Remove.validatePrimaryKey (/usr/local/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/remove.js:205:10)
    at Remove.removeRecord (/usr/local/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/remove.js:133:34)
    at /usr/local/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/remove.js:114:10
    at replenish (/usr/local/lib/node_modules/sails/node_modules/waterline/node_modules/async/lib/async.js:194:21)
    at /usr/local/lib/node_modules/sails/node_modules/waterline/node_modules/async/lib/async.js:211:15
    at Object.async.eachLimit (/usr/local/lib/node_modules/sails/node_modules/waterline/node_modules/async/lib/async.js:171:12)
    at Remove.removeAssociations (/usr/local/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/remove.js:113:9)
    at /usr/local/lib/node_modules/sails/node_modules/waterline/lib/waterline/model/lib/associationMethods/remove.js:81:10
    at iterate (/usr/local/lib/node_modules/sails/node_modules/waterline/node_modules/async/lib/async.js:149:13)
    at Object.async.eachSeries (/usr/local/lib/node_modules/sails/node_modules/waterline/node_modules/async/lib/async.js:165:9)```