### PR TITLE
Return bad request if you are trying to access to /firehose with a http request

### DIFF
--- a/lib/hooks/sockets/lib/index.js
+++ b/lib/hooks/sockets/lib/index.js
@@ -260,7 +260,7 @@ module.exports = function(sails) {
         'get /firehose': function firehose(req, res) {
           if (!req.isSocket) {
             sails.log.error("Cannot subscribe to firehose over HTTP!  Firehose is for socket messages only.");
-            return;
+            return res.send(400);
           }
           if (process.env.NODE_ENV !== 'development') {
             sails.log.warn('Warning: A client socket was just subscribed to the firehose, but the environment is set to `' + process.env.NODE_ENV + '`.' +


### PR DESCRIPTION
Hey guys, 

When I was reading the code I've realized that when you try to go to the /firehose url with a http request, you don't get a response and the request gets pending.

hooks/sockets/lib/index.js

``` javascript
'get /firehose': function firehose(req, res) {
     if (!req.isSocket) {
       sails.log.error("Cannot subscribe to firehose over HTTP!  Firehose is for socket messages only."); 
       return;
      }
```

You can verify that in the http://sailsjs.org/firehose url.

I've just add a bad request response to avoid that behavior:

``` javascript
  return res.send(400);
```

Thanks!
