### PR TITLE
Fix integration tests socket config for sails v0.11+

### DIFF
--- a/test/integration/fixtures/sampleapp/config/local.js
+++ b/test/integration/fixtures/sampleapp/config/local.js
@@ -3,7 +3,7 @@ module.exports = {
 		level: 'silent'
 	},
 	sockets: {
-		authorization: false
+    beforeConnect: false
 	},
 	views: {
     locals: {


### PR DESCRIPTION
debug: Deprecation warning: `sails.config.sockets.authorization` is now `sails.config.sockets.beforeConnect` (setting it for you this time)