### PR TITLE
Fixed bug with sails.request params

### DIFF
--- a/lib/app/request.js
+++ b/lib/app/request.js
@@ -56,7 +56,7 @@ module.exports = function request( /* address, body, cb */ ) {
     url = arguments[0].url;
     method = arguments[0].method;
     headers = arguments[0].headers || {};
-    params = arguments[0].params || arguments[0].data || {};
+    body = arguments[0].params || arguments[0].data || {};
   }
   // console.log('called sails.request() ');
   // console.log('headers: ',headers);


### PR DESCRIPTION
I found that when I try to call in test to an url with sails.request, the params were ignored:

```javascript
   sails.request({
      url: '/id-required',
      method: 'post',
      params: {
        id: '1'
      }
   }, function(err, res, body){
      if(err) return done(err);
      body.status.should.be.equal(200);
      return done();
  });
```

The req.params.all() === {} in the controller. 

I fix it with just renaming the params var, and that's it!