### PR TITLE
Assets folder is now customizable through the sailsrc file.

### DIFF
--- a/lib/hooks/http/index.js
+++ b/lib/hooks/http/index.js
@@ -6,6 +6,7 @@ var path = require('path');
 var _ = require('lodash');
 var express = require('express');
 var methodOverride = require('method-override');
+var rconf = require('../../app/configuration/rc');
 
 
 module.exports = function(sails) {
@@ -45,7 +46,7 @@ module.exports = function(sails) {
         //  • an absolute path
         //  • a relative path from the app root (sails.config.appPath)
         paths: {
-          public: '.tmp/public'
+          public: rconf.assets || '.tmp/public'
         },
 
 


### PR DESCRIPTION
That would be the most simple implementation of what I mentioned in https://github.com/balderdashy/sails/pull/2206

This would not allow folder names such as `false`.

Any thoughts?