### PR TITLE
Adding the route for PUT in association blueprints

### DIFF
--- a/lib/hooks/blueprints/index.js
+++ b/lib/hooks/blueprints/index.js
@@ -364,6 +364,7 @@ module.exports = function(sails) {
               var opts = _.merge({ alias: alias }, routeOpts);
               sails.log.silly('Binding RESTful association blueprint `'+alias+'` for',controllerId);
 
+              _bindRoute( _getAssocRoute('put %s/:parentid/%s/:id?'),      'add', opts );
               _bindRoute( _getAssocRoute('post %s/:parentid/%s/:id?'),     'add', opts );
               _bindRoute( _getAssocRoute('delete %s/:parentid/%s/:id?'),   'remove', opts );
             });


### PR DESCRIPTION
Adding `PUT /:model/:record/:association/:id` to add an association

fix this https://github.com/balderdashy/sails/issues/2573