### PR TITLE
Added ability to pass an array of paths to sails.config.views.partials for handlebars view configurations

### DIFF
--- a/lib/hooks/views/layoutshim.js
+++ b/lib/hooks/views/layoutshim.js
@@ -2,7 +2,8 @@
  * Module dependencies
  */
 
-var path = require('path');
+var path = require('path'),
+		_ = require('lodash');
 
 
 /**
@@ -46,10 +47,20 @@ module.exports = function layoutshim (sails, cb) {
 				var exphbs = require('express-handlebars');
 				return sails.after('hook:http:loaded', function() {
 					sails.log.verbose('Overriding handlebars engine with express-handlebars to implement layout support...');
+					var partials = [];
+
+					if(_.isArray(sails.config.views.partials)){
+						partials = _.map(sails.config.views.partials, function(partial){
+							return path.join('views', partial || '');
+						});
+					}else{
+						partials.push(path.join('views', sails.config.views.partials || ''));
+					}
+					
 					var hbs = exphbs.create({
 						defaultLayout: path.join('..', (sails.config.views.layout + '.' + (sails.config.views.extension || 'handlebars')) || ''),
 						helpers: sails.config.views.helpers || {},
-						partialsDir: path.join('views', sails.config.views.partials || '')
+						partialsDir: partials
 					});
 
 					sails.config.views.engine.fn = hbs.engine;


### PR DESCRIPTION
The [express-handlebars](https://github.com/ericf/express-handlebars#partialsdirviewspartials) package allows for multiple partial directories.  Instead of passing a single string you can pass an array of strings.  This commit changes the ```layoutshim.js``` file which runs the handlebars view configuration. 

This functionality is beneficial in larger projects where grouping partials by controller makes more sense than putting all partials into a single folder. Here is an example use case:

```
── views/
   |── category
   |─── category_page.handlebars
   |─── partials
      |─── list_item.handlebars
      |─── left_nav.handlebars
   |── product
   |─── product_page.handlebars
   |─── partials
      |─── price_box.handlebars
      |─── description.handlebars

```