### PR TITLE
fix favicon if default gruntfile.js isn't used

### DIFF
--- a/lib/hooks/http/middleware/defaults.js
+++ b/lib/hooks/http/middleware/defaults.js
@@ -59,7 +59,7 @@ module.exports = function(sails, app) {
       }
     })(),
 
-    favicon: express.favicon(),
+    favicon: express.favicon('assets/favicon.ico'),
 
     /**
      * Track request start time as soon as possible


### PR DESCRIPTION
This problem has been masked for a long time because Grunt always copied the `favicon.ico` to the `public` folder and overrided `serve-favicon`