### PR TITLE
disable express' built in `x-powered-by` header

### DIFF
--- a/lib/hooks/http/initialize.js
+++ b/lib/hooks/http/initialize.js
@@ -28,7 +28,7 @@ module.exports = function(sails) {
         // Required to be here due to dynamic NODE_ENV settings via command line args
         // (i.e. if we `require` this above w/ everything else, the NODE_ENV might not be set properly yet)
         var express = require('express');
-
+        app.disable('x-powered-by');
 
 
         // Create express server

--- a/lib/hooks/http/initialize.js
+++ b/lib/hooks/http/initialize.js
@@ -28,12 +28,11 @@ module.exports = function(sails) {
         // Required to be here due to dynamic NODE_ENV settings via command line args
         // (i.e. if we `require` this above w/ everything else, the NODE_ENV might not be set properly yet)
         var express = require('express');
-        app.disable('x-powered-by');
 
 
         // Create express server
         var app = sails.hooks.http.app = express();
-
+        app.disable('x-powered-by');
         // (required by Express 3.x)
         var usingSSL = sails.config.ssl.key && sails.config.ssl.cert;
 


### PR DESCRIPTION
sails sets it anyways. If someone disables sails' middleware for this header, they probably don't want express' either.