### PR TITLE
[Patch] Blueprints actionUtil::parsePk also checks params for where.id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### master
 
+* [ENHANCEMENT] Blueprints actionUtil::parsePk also checks params for where.id
 * [ENHANCEMENT] Support JSON sorting syntax in blueprints [#2449](https://github.com/balderdashy/sails/issues/2449)
 * [ENHANCEMENT] Support private modules as hooks [#3022](https://github.com/balderdashy/sails/issues/3022)
 * [BUGFIX] Fixed issues with subscribing sockets to new model instances in a clustered environment [#2990](https://github.com/balderdashy/sails/issues/2990), [#3008](https://github.com/balderdashy/sails/issues/3008)

--- a/lib/hooks/blueprints/actionUtil.js
+++ b/lib/hooks/blueprints/actionUtil.js
@@ -115,6 +115,15 @@ module.exports = {
 
     var pk = req.options.id || (req.options.where && req.options.where.id) || req.param('id');
 
+    if (!pk) {
+      var where = req.param('where');
+      // If `where` parameter is a string, try to interpret it as JSON
+      if (_.isString(where)) {
+        where = tryToParseJSON(where);
+      }
+      pk = where && where.id;
+    }
+
     // TODO: make this smarter...
     // (e.g. look for actual primary key of model and look for it
     //  in the absence of `id`.)


### PR DESCRIPTION
Blueprints actionUtil::parsePk does a thorough check of most places where an id may be provided, but doesn't inspect the `where` property on the `params` which is where the `where` object is retrieved for `find` methods. If there isn't a specific reason for not looking in this location I'd suggest adding it. This will allow a `delete` from the socket client with the id passed on the options rather than the URL.
