### PR TITLE
Remove unused dependency variable

### DIFF
--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -3,7 +3,6 @@
  */
 
 var _ = require('lodash');
-var defaultsDeep = require('merge-defaults');
 var async = require('async');
 
 


### PR DESCRIPTION
It seems like this dependency variable is unused since commit 3b77489c . Is this intentional or can it be removed?