### PR TITLE
Fix #2636 RangeError: Maximum call stack size exceeded on PubSub hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### master
 
+* [BUGFIX] Fix [RangeError: Maximum call stack size exceeded] error in PubSub hook
 * [ENHANCEMENT] Support layout for Ractive template engine
 
 

--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -168,6 +168,10 @@ module.exports = function(sails) {
           var id = record[this.primaryKey] || record;
           // Get the socket room to publish to
           var room = this.room(id, "message");
+
+          // Ensure that we're working with a clean, unencumbered object
+          data = _.cloneDeep(data);
+
           // Create the payload
           var payload = {
             verb: "messaged",
@@ -537,7 +541,7 @@ module.exports = function(sails) {
         options = options || {};
 
         // Ensure that we're working with a clean, unencumbered object
-        changes = _.clone(changes);
+        changes = _.cloneDeep(changes);
 
         // Enforce valid usage
         var validId = _.isString(id) || _.isFinite(id);


### PR DESCRIPTION
Make sure the object (i.e Model) is clean in "publishUpdate", "message" methods.

For the "publishCreate" method, it seems like the code below is avoiding the error.
```JavaScript
var legacyData = _.cloneDeep({
  verb: 'create',
  data: values,
  model: self.identity,
  id: values[this.primaryKey]
});
```