### PR TITLE
Export shadow routes to sails.config.routes in dev environment.

### DIFF
--- a/lib/hooks/blueprints/index.js
+++ b/lib/hooks/blueprints/index.js
@@ -98,6 +98,8 @@ module.exports = function(sails) {
         autoWatch: true,
 
 
+
+
         // (TODO: generated comments for jsonp configuration needs to be updated w/ new options)
         // (TODO: need to mention new `req.options` stuff in generated comments)
 
@@ -165,6 +167,13 @@ module.exports = function(sails) {
       _.each(sails.middleware.controllers, function (controller) {
         _.defaults(controller, hook.middleware);
       });
+    },
+
+    exportShadowRoutes: function(path, type) {
+      if (process.env.NODE_ENV !== 'production') {
+        sails.config.routes[type] = sails.config.routes[type] || [];
+        sails.config.routes[type].push(path);
+      }
     },
 
     bindShadowRoutes: function() {
@@ -262,12 +271,16 @@ module.exports = function(sails) {
             var actionRoute = baseRoute + '/' + actionId.toLowerCase() + '/:id?';
             sails.log.silly('Binding action ('+actionId.toLowerCase()+') blueprint/shadow route for controller:',controllerId);
             sails.router.bind(actionRoute, controller[actionId.toLowerCase()], null, opts);
+            if(['sails', 'identity', 'globalid'].indexOf(actionId.toLowerCase()) === -1) {
+              hook.exportShadowRoutes(actionRoute, 'actions');
+            }
           }
 
           // Bind base route to index action, if `index` shadows are not disabled
           if (config.index !== false && actionId.match(/^index$/i)) {
             sails.log.silly('Binding index blueprint/shadow route for controller:',controllerId);
             sails.router.bind(baseRoute, controller.index, null, opts);
+            hook.exportShadowRoutes(baseRoute, 'base')
           }
         });
 
@@ -314,24 +327,25 @@ module.exports = function(sails) {
 
           // Binds a route to the specifed action using _getAction, and sets the action and controller
           // options for req.options
-          var _bindRoute = function (path, action, options) {
+          var _bindRoute = function (path, action, options, type) {
             options = options || routeOpts;
             options = _.extend({}, options, {action: action, controller: controllerId});
             sails.router.bind ( path, _getAction(action), null, options);
-
+            hook.exportShadowRoutes(path, type)
           };
 
           // Bind URL-bar "shortcuts"
           // (NOTE: in a future release, these may be superceded by embedding actions in generated controllers
           //  and relying on action blueprints instead.)
           if ( config.shortcuts ) {
+            console.log(config.shortcuts);
             sails.log.silly('Binding shortcut blueprint/shadow routes for model ', modelId, ' on controller:', controllerId);
 
-            _bindRoute(_getRoute('%s/find'), 'find');
-            _bindRoute(_getRoute('%s/find/:id'), 'findOne');
-            _bindRoute(_getRoute('%s/create'), 'create');
-            _bindRoute(_getRoute('%s/update/:id'), 'update');
-            _bindRoute(_getRoute('%s/destroy/:id?'), 'destroy');
+            _bindRoute(_getRoute('%s/find'), 'find', undefined, 'shortcuts');
+            _bindRoute(_getRoute('%s/find/:id'), 'findOne', undefined, 'shortcuts');
+            _bindRoute(_getRoute('%s/create'), 'create', undefined, 'shortcuts');
+            _bindRoute(_getRoute('%s/update/:id'), 'update', undefined, 'shortcuts');
+            _bindRoute(_getRoute('%s/destroy/:id?'), 'destroy', undefined, 'shortcuts');
 
             // Bind add/remove "shortcuts" for each `collection` associations
             _(Model.associations).where({type: 'collection'}).forEach(function (association) {
@@ -340,8 +354,8 @@ module.exports = function(sails) {
               var opts = _.merge({ alias: alias }, routeOpts);
 
               sails.log.silly('Binding "shortcuts" to association blueprint `'+alias+'` for',controllerId);
-              _bindRoute( _getAssocRoute('%s/:parentid/%s/add/:id?'),      'add' , opts );
-              _bindRoute( _getAssocRoute('%s/:parentid/%s/remove/:id?'),   'remove', opts );
+              _bindRoute( _getAssocRoute('%s/:parentid/%s/add/:id?'),      'add' , opts, 'shortcuts' );
+              _bindRoute( _getAssocRoute('%s/:parentid/%s/remove/:id?'),   'remove', opts, 'shortcuts');
             });
           }
 
@@ -349,12 +363,12 @@ module.exports = function(sails) {
           if ( config.rest ) {
             sails.log.silly('Binding RESTful blueprint/shadow routes for model+controller:',controllerId);
 
-            _bindRoute(_getRestRoute('get %s'), 'find');
-            _bindRoute(_getRestRoute('get %s/:id'), 'findOne');
-            _bindRoute(_getRestRoute('post %s'), 'create');
-            _bindRoute(_getRestRoute('put %s/:id'), 'update');
-            _bindRoute(_getRestRoute('post %s/:id'), 'update');
-            _bindRoute(_getRestRoute('delete %s/:id?'), 'destroy');
+            _bindRoute(_getRestRoute('get %s'), 'find', undefined, 'rest');
+            _bindRoute(_getRestRoute('get %s/:id'), 'findOne', undefined, 'rest');
+            _bindRoute(_getRestRoute('post %s'), 'create', undefined, 'rest');
+            _bindRoute(_getRestRoute('put %s/:id'), 'update', undefined, 'rest');
+            _bindRoute(_getRestRoute('post %s/:id'), 'update', undefined, 'rest');
+            _bindRoute(_getRestRoute('delete %s/:id?'), 'destroy', undefined, 'rest');
 
             // Bind "rest" blueprint/shadow routes based on known associations in our model's schema
             // Bind add/remove for each `collection` associations
@@ -364,8 +378,8 @@ module.exports = function(sails) {
               var opts = _.merge({ alias: alias }, routeOpts);
               sails.log.silly('Binding RESTful association blueprint `'+alias+'` for',controllerId);
 
-              _bindRoute( _getAssocRoute('post %s/:parentid/%s/:id?'),     'add', opts );
-              _bindRoute( _getAssocRoute('delete %s/:parentid/%s/:id?'),   'remove', opts );
+              _bindRoute( _getAssocRoute('post %s/:parentid/%s/:id?'),     'add', opts, 'rest' );
+              _bindRoute( _getAssocRoute('delete %s/:parentid/%s/:id?'),   'remove', opts, 'rest' );
             });
 
             // and populate for both `collection` and `model` associations
@@ -375,7 +389,7 @@ module.exports = function(sails) {
               var opts = _.merge({ alias: alias }, routeOpts);
               sails.log.silly('Binding RESTful association blueprint `'+alias+'` for',controllerId);
 
-              _bindRoute( _getAssocRoute('get %s/:parentid/%s/:id?'), 'populate', opts );
+              _bindRoute( _getAssocRoute('get %s/:parentid/%s/:id?'), 'populate', opts, 'rest' );
             });
           }
         }
@@ -451,4 +465,3 @@ module.exports = function(sails) {
   }
 
 };
-


### PR DESCRIPTION
It is sometimes super-useful to see all the routes sails create and not having to look through the `--silly` logs. Especially when used with https://github.com/balderdashy/sails-hook-dev

What do you think? Should this be behind some settings flag?