### PR TITLE
Added ability to create custom sails commands

### DIFF
--- a/bin/sails-command-hook.js
+++ b/bin/sails-command-hook.js
@@ -1,0 +1,38 @@
+var path = require('path');
+var buildDictionary = require('sails-build-dictionary');
+var _ = require('lodash');
+var program = require('commander');
+
+module.exports = function() {
+  var cliArguments = _.initial(arguments);
+  var commandName = cliArguments.shift();
+  var args = cliArguments;
+  buildDictionary.optional({
+    dirname: path.resolve('.', "node_modules"),
+    filter: /^(package\.json)$/,
+    depth: 2
+  }, function(err, packages) {
+    var objectKeys = Object.keys(packages);
+    for(var i = 0; i < objectKeys.length; i++){
+      var pkg = packages[objectKeys[i]];
+      var cmd = loadModule(pkg, commandName);
+      if(cmd){
+        cmd.execute(args);
+        return;
+      }
+    }
+    return program.usageMinusWildcard();
+  });
+};
+
+function loadModule(package, commandName){
+  if (package['package.json'] && package['package.json'].sails && package['package.json'].sails.isCommand) {
+    var module = require(path.resolve('.', 'node_modules', package['package.json'].name));
+    if(module.command){
+      program.command(module.command); //add to list of help commands
+      if (module.command === commandName) {
+        return module;
+      }
+    }
+  }
+}

--- a/bin/sails.js
+++ b/bin/sails.js
@@ -12,6 +12,7 @@ var NOOP = function() {};
 
 
 
+
 program
   .version(package.version, '-v, --version');
 
@@ -151,7 +152,7 @@ cmd.action(program.usageMinusWildcard);
 // Mask the '*' in `help`.
 program
   .command('*')
-  .action(program.usageMinusWildcard);
+  .action(require('./sails-command-hook.js'));
 
 
 


### PR DESCRIPTION
Currently `sails` does not have the ability to create custom commands at the `sails` command line. This PR adds that ability with the following rules:

- A command hook needs to specify `sails: { isCommand: true}` in the `package.json`
- A command hook needs to export an object with 2 properties `command` and `execute`.
  - the `command` property should be a string representing the command name
  - the `execute` property should be a function that will be called with the additional arguments.

For example a module like this will add an `azure` command that can be used like this `sails azure deploy`
```javascript
module.exports = {
  command: 'azure',
   execute: function(args) {
     console.log(args) // will log ['deploy']
  }
}
```

The motivation behind this PR was https://github.com/balderdashy/sails/pull/2663. The way that is currently set up is that if you do `sails deploy` it defaults to publishing to Azure. I think it would be a much nicer experience if the command would be `sails azure deploy` and in the future perhaps a `sails heroku deploy` etc. Additionally, this would allow the `azure` functionality to be wrapped up into it's own (opt-in) module.