### PR TITLE
Properly add/cleanup process event listeners.

### DIFF
--- a/lib/app/lower.js
+++ b/lib/app/lower.js
@@ -111,6 +111,12 @@ module.exports = function lower(cb) {
           sails.removeAllListeners(key);
         }
 
+        var listeners = sails._processListeners;
+        process.removeListener('SIGUSR2', listeners.sigusr2);
+        process.removeListener('SIGINT', listeners.sigint);
+        process.removeListener('SIGTERM', listeners.sigterm);
+        process.removeListener('exit', listeners.exit);
+
         // If `sails.config.process.removeAllListeners` is set, do that.
         if (sails.config && sails.config.process && sails.config.process.removeAllListeners) {
           process.removeAllListeners();

--- a/lib/app/private/initialize.js
+++ b/lib/app/private/initialize.js
@@ -24,25 +24,31 @@ module.exports = function initialize(cb) {
   // Indicate that server is starting
   sails.log.verbose('Starting app at ' + sails.config.appPath + '...');
 
-  // Add "beforeShutdown" events
-  process.once('SIGUSR2', function() {
-    sails.lower(function() {
-      process.kill(process.pid, 'SIGUSR2');
-    });
-  });
+  var listeners = {
+    sigusr2: function() {
+      sails.lower(function() {
+        process.kill(process.pid, 'SIGUSR2');
+      });
+    },
+    sigint: function() {
+      sails.lower(process.exit);
+    },
+    sigterm: function() {
+      sails.lower(process.exit);
+    },
+    exit: function() {
+      if (!sails._exiting) sails.lower();
+    }
+  };
 
-  // Roadmap: can we get away w/ making this `.once()`?
-  process.on('SIGINT', function() {
-    sails.lower(process.exit);
-  });
-  // Roadmap: can we get away w/ making this `.once()`?
-  process.on('SIGTERM', function() {
-    sails.lower(process.exit);
-  });
-  // Roadmap: can we get away w/ making this `.once()`?
-  process.on('exit', function() {
-    if (!sails._exiting) sails.lower();
-  });
+  // Add "beforeShutdown" events
+  process.on('SIGUSR2', listeners.sigusr2);
+
+  process.on('SIGINT', listeners.sigint);
+  process.on('SIGTERM', listeners.sigterm);
+  process.on('exit', listeners.exit);
+
+  sails._processListeners = listeners;
 
   // Run the app bootstrap
   sails.runBootstrap(function afterBootstrap(err) {


### PR DESCRIPTION
Causes issues when using sails in combination with test frameworks that
also adds process event listeners (e.g cucumber).

Don't use process.once as this replaces any existing listeners.
Properly remove listener using process.removeListener which doesn't
remove other listeners than our own.

This also solves the problem of doing multiple sails.lift/sails.lower (typically 
in a test framework) which would give node warnings like this: 
(node) warning: possible EventEmitter memory leak detected. 11 exit listeners
 added. Use emitter.setMaxListeners() to increase limit.