### PR TITLE
Properly add/cleanup process event listeners.

### DIFF
--- a/lib/app/lower.js
+++ b/lib/app/lower.js
@@ -110,6 +110,15 @@ module.exports = function lower(cb) {
           sails.removeAllListeners(eventName);
         });
 
+        var listeners = sails._processListeners;
+        if (listeners) {
+          process.removeListener('SIGUSR2', listeners.sigusr2);
+          process.removeListener('SIGINT', listeners.sigint);
+          process.removeListener('SIGTERM', listeners.sigterm);
+          process.removeListener('exit', listeners.exit);
+        }
+        sails._processListeners = null;
+
         // If `sails.config.process.removeAllListeners` is set, do that.
         if (sails.config && sails.config.process && sails.config.process.removeAllListeners) {
           process.removeAllListeners();

--- a/lib/app/private/initialize.js
+++ b/lib/app/private/initialize.js
@@ -24,25 +24,31 @@ module.exports = function initialize(cb) {
   // Indicate that server is starting
   sails.log.verbose('Starting app at ' + sails.config.appPath + '...');
 
-  // Add "beforeShutdown" events
-  process.once('SIGUSR2', function() {
-    sails.lower(function() {
-      process.kill(process.pid, 'SIGUSR2');
-    });
-  });
+  var listeners = {
+    sigusr2: function() {
+      sails.lower(function() {
+        process.kill(process.pid, 'SIGUSR2');
+      });
+    },
+    sigint: function() {
+      sails.lower(process.exit);
+    },
+    sigterm: function() {
+      sails.lower(process.exit);
+    },
+    exit: function() {
+      if (!sails._exiting) sails.lower();
+    }
+  };
 
-  // Roadmap: can we get away w/ making this `.once()`?
-  process.on('SIGINT', function() {
-    sails.lower(process.exit);
-  });
-  // Roadmap: can we get away w/ making this `.once()`?
-  process.on('SIGTERM', function() {
-    sails.lower(process.exit);
-  });
-  // Roadmap: can we get away w/ making this `.once()`?
-  process.on('exit', function() {
-    if (!sails._exiting) sails.lower();
-  });
+  // Add "beforeShutdown" events
+  process.once('SIGUSR2', listeners.sigusr2);
+
+  process.on('SIGINT', listeners.sigint);
+  process.on('SIGTERM', listeners.sigterm);
+  process.on('exit', listeners.exit);
+
+  sails._processListeners = listeners;
 
   // Run the app bootstrap
   sails.runBootstrap(function afterBootstrap(err) {

--- a/test/integration/lift.lower.test.js
+++ b/test/integration/lift.lower.test.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+var Sails = require('../../lib/app');
+
+describe('sails being lifted and lowered (e.g in a test framework)', function() {
+
+    for (var i = 0; i < 15; ++i) {
+
+        describe('Test suite ' + i, function() {
+            var sailsServer = null;
+
+            before(function (done) {
+                assert.doesNotThrow(function() {
+                    Sails().lift({
+                        port: 1342,
+                        environment: process.env.TEST_ENV,
+                        log: {
+                            level: 'error'
+                        },
+                        globals: false,
+                        hooks: {
+                            grunt: false,
+                        }
+                    }, function (err, sails) {
+                        sailsServer = sails;
+                        return done(err);
+                    });
+                });
+            });
+
+            after(function (done) {
+                sailsServer.lower(function (err) {
+                    sailsServer = null;
+                    done(err);
+                });
+            });
+
+            it('run a test', function (done) {
+                assert(sailsServer);
+                done();
+            });
+
+        });
+    }
+});

--- a/test/unit/app.lower.test.js
+++ b/test/unit/app.lower.test.js
@@ -1,0 +1,46 @@
+
+var assert = require('assert');
+var async = require('async');
+var Sails = require('../../lib').constructor;
+
+describe('app.lower', function (){
+
+  it('should clean up event listeners', function (done) {
+
+    var beforeListeners = {
+      sigusr2: process.listeners('SIGUSR2'),
+      sigint: process.listeners('SIGINT'),
+      sigterm: process.listeners('SIGTERM'),
+      exit: process.listeners('exit')
+    };
+
+    var app = new Sails();
+    var options = {
+      globals: false,
+      log: {
+        level: 'error'
+      }
+    };
+
+    async.series([
+      function(cb) {
+        app.load(options, cb);
+      },
+      app.initialize,
+      app.lower
+    ], function (err) {
+      assert.equal(beforeListeners.sigusr2.length,
+                   process.listeners('SIGUSR2').length);
+      assert.equal(beforeListeners.sigint.length,
+                   process.listeners('SIGINT').length);
+      assert.equal(beforeListeners.sigterm.length,
+                   process.listeners('SIGTERM').length);
+      assert.equal(beforeListeners.exit.length,
+                   process.listeners('exit').length);
+      done(err);
+    });
+
+  });
+
+});
+


### PR DESCRIPTION
Add and cleanup process event listeners properly.

Fixes warnings when doing lift/lower multiple times, e.g in before() and
after() functions in a test suite.
    
Tests:
  test/integration/lift.lower.test.js
  test/unit/app.lower.test.js