### PR TITLE
Allow clients to read custom response headers

### DIFF
--- a/lib/hooks/cors/index.js
+++ b/lib/hooks/cors/index.js
@@ -23,6 +23,7 @@ module.exports = function(sails) {
 				credentials: true,
 				methods: 'GET, POST, PUT, DELETE, OPTIONS, HEAD',
 				headers: 'content-type',
+				exposeHeaders: '',
         securityLevel: 0,
 			}
 		},
@@ -180,6 +181,9 @@ module.exports = function(sails) {
         // Determine whether or not to allow cookies to be passed cross-origin
 				res.set('Access-Control-Allow-Credentials', !_.isUndefined(routeCorsConfig.credentials) ? routeCorsConfig.credentials : sails.config.cors.credentials);
 
+	// This header lets a server whitelist headers that browsers are allowed to access
+        res.set('Access-Control-Expose-Headers', !_.isUndefined(routeCorsConfig.exposeHeaders) ? routeCorsConfig.exposeHeaders : sails.config.cors.exposeHeaders);
+
         // Handle preflight requests
 				if (req.method == "OPTIONS") {
 					res.set('Access-Control-Allow-Methods', !_.isUndefined(routeCorsConfig.methods) ? routeCorsConfig.methods : sails.config.cors.methods);
@@ -204,6 +208,7 @@ module.exports = function(sails) {
 			res.set('Access-Control-Allow-Credentials', '');
 			res.set('Access-Control-Allow-Methods', '');
 			res.set('Access-Control-Allow-Headers', '');
+			res.set('Access-Control-Expose-Headers', '');
 		}
 
 		next();


### PR DESCRIPTION
I was trying to read a Content-Range header in angularjs in order to build a proper pagination. But it simply was not visible to angular because the header was not exposed. We must allow developers to whitelist allowed headers with **Access-Control-Expose-Headers**.

https://github.com/balderdashy/sails/issues/2550
https://github.com/balderdashy/sails/issues/2542