### PR TITLE
Added support for ssl using a pfx certificate

### DIFF
--- a/lib/hooks/http/initialize.js
+++ b/lib/hooks/http/initialize.js
@@ -34,7 +34,7 @@ module.exports = function(sails) {
         var app = sails.hooks.http.app = express();
         app.disable('x-powered-by');
         // (required by Express 3.x)
-        var usingSSL = sails.config.ssl.key && sails.config.ssl.cert;
+        var usingSSL = (sails.config.ssl.key && sails.config.ssl.cert) || sails.config.ssl.pfx;
 
         // Merge SSL into server options
         var serverOptions = sails.config.http.serverOptions || {};


### PR DESCRIPTION
I added support for .pfx ssl certificates according to the node docs: http://nodejs.org/api/https.html#https_https_createserver_options_requestlistener