### PR TITLE
Disabling CSRF via web-sockets accessed routes

### DIFF
--- a/lib/hooks/csrf/index.js
+++ b/lib/hooks/csrf/index.js
@@ -80,8 +80,12 @@ module.exports = function(sails) {
             } catch(err) {
               // Only attempt to handle invalid csrf tokens
               if (err.message != 'invalid csrf token') throw err;
+              
+              var path = req.path;
+              if(req.isSocket)
+                path = req._parsedUrl.path;
 
-              var isRouteDisabled  = sails.config.csrf.routesDisabled.split(',').map(trim).indexOf(req.path) > -1;
+              var isRouteDisabled  = sails.config.csrf.routesDisabled.split(',').map(trim).indexOf(path) > -1;
 
               if (isRouteDisabled) {
                 return next();


### PR DESCRIPTION
When you do a post to a route which is in the `sails.config.csrf.routesDisabled` string via a web-socket CSRF was not disabled.