### PR TITLE
req.param() is broken for boolean false params

### DIFF
--- a/lib/router/req.js
+++ b/lib/router/req.js
@@ -94,7 +94,12 @@ module.exports = function buildRequest (_req) {
 
       // Grab the value of the parameter from the appropriate place
       // and return it
-      return params[paramName] || defaultValue;
+      if (typeof params[paramName] !== 'undefined') {
+        return params[paramName];
+      } else {
+        return defaultValue;
+      }
+      
     },
     wantsJSON: (_req && _req.wantsJSON) || true,
     method: 'GET'


### PR DESCRIPTION
for example if you posted data `{ isPirate: false }` and you run `req.param('isPirate')` from a controller, you'd get `undefined` returned as you didn't specify a `defaultValue` - so basically you couldn't post params that where === false. I think this edit captures the spirit of the OR guard used previously. If your happy with this, I would be ok with writing a test... if needed.