### PR TITLE
make default responses work when views hook disabled

### DIFF
--- a/lib/hooks/responses/defaults/badRequest.js
+++ b/lib/hooks/responses/defaults/badRequest.js
@@ -21,6 +21,11 @@ module.exports = function badRequest(data, options) {
   var req = this.req;
   var res = this.res;
   var sails = req._sails;
+  var guessView = function () {
+    res.guessView({ data: data }, function couldNotGuessView () {
+      return res.jsonx(data);
+    });
+  };
 
   // Set status code
   res.status(400);
@@ -55,10 +60,7 @@ module.exports = function badRequest(data, options) {
   }
 
   // If no second argument provided, try to serve the implied view,
-  // but fall back to sending JSON(P) if no view can be inferred.
-  else return res.guessView({ data: data }, function couldNotGuessView () {
-    return res.jsonx(data);
-  });
+  // but fall back to sending JSON(P) if views hook disabled or no view can be inferred.
+  else return sails.hooks.views ? guessView() : res.jsonx(data);
 
 };
-

--- a/lib/hooks/responses/defaults/created.js
+++ b/lib/hooks/responses/defaults/created.js
@@ -17,6 +17,11 @@ module.exports = function sendOK (data, options) {
   var req = this.req;
   var res = this.res;
   var sails = req._sails;
+  var guessView = function () {
+    res.guessView({ data: data }, function couldNotGuessView () {
+      return res.jsonx(data);
+    });
+  };
 
   sails.log.silly('res.created() :: Sending 201 ("CREATED") response');
 
@@ -40,9 +45,7 @@ module.exports = function sendOK (data, options) {
   }
 
   // If no second argument provided, try to serve the implied view,
-  // but fall back to sending JSON(P) if no view can be inferred.
-  else return res.guessView({ data: data }, function couldNotGuessView () {
-    return res.jsonx(data);
-  });
+  // but fall back to sending JSON(P) if views hook disabled or no view can be inferred.
+  else return sails.hooks.views ? guessView() : res.jsonx(data);
 
 };

--- a/lib/hooks/responses/defaults/forbidden.js
+++ b/lib/hooks/responses/defaults/forbidden.js
@@ -52,26 +52,30 @@ module.exports = function forbidden (data, options) {
   }
 
   // If no second argument provided, try to serve the default view,
-  // but fall back to sending JSON(P) if any errors occur.
-  else return res.view('403', { data: data }, function (err, html) {
-
-    // If a view error occured, fall back to JSON(P).
-    if (err) {
-      //
-      // Additionally:
-      // • If the view was missing, ignore the error but provide a verbose log.
-      if (err.code === 'E_VIEW_FAILED') {
-        sails.log.verbose('res.forbidden() :: Could not locate view for error page (sending JSON instead).  Details: ',err);
-      }
-      // Otherwise, if this was a more serious error, log to the console with the details.
-      else {
-        sails.log.warn('res.forbidden() :: When attempting to render error page view, an error occured (sending JSON instead).  Details: ', err);
-      }
+  // but fall back to sending JSON(P) if any errors occur or views hook disabled.
+  else return (function fallback () {
+    if (sails.hooks.views === undefined) {
       return res.jsonx(data);
     }
+    res.view('403', { data: data }, function (err, html) {
 
-    return res.send(html);
-  });
+      // If a view error occured, fall back to JSON(P).
+      if (err) {
+        //
+        // Additionally:
+        // • If the view was missing, ignore the error but provide a verbose log.
+        if (err.code === 'E_VIEW_FAILED') {
+          sails.log.verbose('res.forbidden() :: Could not locate view for error page (sending JSON instead).  Details: ',err);
+        }
+        // Otherwise, if this was a more serious error, log to the console with the details.
+        else {
+          sails.log.warn('res.forbidden() :: When attempting to render error page view, an error occured (sending JSON instead).  Details: ', err);
+        }
+        return res.jsonx(data);
+      }
+
+      return res.send(html);
+    });
+  })();
 
 };
-

--- a/lib/hooks/responses/defaults/notFound.js
+++ b/lib/hooks/responses/defaults/notFound.js
@@ -57,26 +57,30 @@ module.exports = function notFound (data, options) {
   }
 
   // If no second argument provided, try to serve the default view,
-  // but fall back to sending JSON(P) if any errors occur.
-  else return res.view('404', { data: data }, function (err, html) {
-
-    // If a view error occured, fall back to JSON(P).
-    if (err) {
-      //
-      // Additionally:
-      // • If the view was missing, ignore the error but provide a verbose log.
-      if (err.code === 'E_VIEW_FAILED') {
-        sails.log.verbose('res.notFound() :: Could not locate view for error page (sending JSON instead).  Details: ',err);
-      }
-      // Otherwise, if this was a more serious error, log to the console with the details.
-      else {
-        sails.log.warn('res.notFound() :: When attempting to render error page view, an error occured (sending JSON instead).  Details: ', err);
-      }
+  // but fall back to sending JSON(P) if any errors occur or views hook disabled.
+  else return (function fallback () {
+    if (sails.hooks.views === undefined) {
       return res.jsonx(data);
     }
+    res.view('404', { data: data }, function (err, html) {
 
-    return res.send(html);
-  });
+      // If a view error occured, fall back to JSON(P).
+      if (err) {
+        //
+        // Additionally:
+        // • If the view was missing, ignore the error but provide a verbose log.
+        if (err.code === 'E_VIEW_FAILED') {
+          sails.log.verbose('res.notFound() :: Could not locate view for error page (sending JSON instead).  Details: ',err);
+        }
+        // Otherwise, if this was a more serious error, log to the console with the details.
+        else {
+          sails.log.warn('res.notFound() :: When attempting to render error page view, an error occured (sending JSON instead).  Details: ', err);
+        }
+        return res.jsonx(data);
+      }
+
+      return res.send(html);
+    });
+  })();
 
 };
-

--- a/lib/hooks/responses/defaults/ok.js
+++ b/lib/hooks/responses/defaults/ok.js
@@ -17,6 +17,11 @@ module.exports = function sendOK (data, options) {
   var req = this.req;
   var res = this.res;
   var sails = req._sails;
+  var guessView = function () {
+    res.guessView({ data: data }, function couldNotGuessView () {
+      return res.jsonx(data);
+    });
+  };
 
   sails.log.silly('res.ok() :: Sending 200 ("OK") response');
 
@@ -40,9 +45,7 @@ module.exports = function sendOK (data, options) {
   }
 
   // If no second argument provided, try to serve the implied view,
-  // but fall back to sending JSON(P) if no view can be inferred.
-  else return res.guessView({ data: data }, function couldNotGuessView () {
-    return res.jsonx(data);
-  });
+  // but fall back to sending JSON(P) if views hook disabled or no view can be inferred.
+  else return sails.hooks.views ? guessView() : res.jsonx(data);
 
 };

--- a/lib/hooks/responses/defaults/serverError.js
+++ b/lib/hooks/responses/defaults/serverError.js
@@ -52,26 +52,29 @@ module.exports = function serverError (data, options) {
   }
 
   // If no second argument provided, try to serve the default view,
-  // but fall back to sending JSON(P) if any errors occur.
-  else return res.view('500', { data: data }, function (err, html) {
-
-    // If a view error occured, fall back to JSON(P).
-    if (err) {
-      //
-      // Additionally:
-      // • If the view was missing, ignore the error but provide a verbose log.
-      if (err.code === 'E_VIEW_FAILED') {
-        sails.log.verbose('res.serverError() :: Could not locate view for error page (sending JSON instead).  Details: ',err);
-      }
-      // Otherwise, if this was a more serious error, log to the console with the details.
-      else {
-        sails.log.warn('res.serverError() :: When attempting to render error page view, an error occured (sending JSON instead).  Details: ', err);
-      }
+  // but fall back to sending JSON(P) if any errors occur or views hook disabled.
+  else return (function fallback () {
+    if (sails.hooks.views === undefined) {
       return res.jsonx(data);
     }
+    res.view('500', { data: data }, function (err, html) {
+      // If a view error occured, fall back to JSON(P).
+      if (err) {
+        //
+        // Additionally:
+        // • If the view was missing, ignore the error but provide a verbose log.
+        if (err.code === 'E_VIEW_FAILED') {
+          sails.log.verbose('res.serverError() :: Could not locate view for error page (sending JSON instead).  Details: ',err);
+        }
+        // Otherwise, if this was a more serious error, log to the console with the details.
+        else {
+          sails.log.warn('res.serverError() :: When attempting to render error page view, an error occured (sending JSON instead).  Details: ', err);
+        }
+        return res.jsonx(data);
+      }
 
-    return res.send(html);
-  });
+      return res.send(html);
+    });
+  })();
 
 };
-


### PR DESCRIPTION
`res.guessView` and `res.view` is always `undefined` when views hook is disabled.