### PR TITLE
give ability for hooks to modify loaded models before orm is built

### DIFF
--- a/lib/hooks/orm/index.js
+++ b/lib/hooks/orm/index.js
@@ -85,6 +85,7 @@ module.exports = function(sails) {
         // Load model and adapter definitions defined in the project
         _loadModules: function (next) {
           loadAppModelsAndAdapters(next);
+          sails.emit('hook:orm:models:loaded');
         },
 
         // Load any adapters for connections with "forceLoadAdapter"


### PR DESCRIPTION
According to [orm/index.js#L73-L78](https://github.com/balderdashy/sails/blob/master/lib/hooks/orm/index.js#L73-L78), a hook could be able to add or alter models by modifying `sails.models` after event `hook:orm:loaded` and call for a reload.

The line responsible for such a behavior is [this one](https://github.com/balderdashy/sails/blob/master/lib/hooks/orm/load-user-modules.js#L25) `sails.models = _.extend(sails.models || {}, modules);` but as lodash extend is not a deep copy feature, it only provides ability to *add* new models but not to *alter* existing ones.

Because each model in `sails.models` is populated by bunch of stuff related to waterline, it seems better not to try to implement deep copy, but i rather propose an event that would trigger just after that merge, giving the ability to a hook to alter `sails.models`. It should be before any other step in the process so it will go through a normal flow of normalization and etc...

(edit: [usecase](https://github.com/ynk/sails-hook-gravatar/tree/fix/methodAttachedToInstance))