### PR TITLE
Pass configuration to sails deploy

### DIFF
--- a/bin/sails-deploy.js
+++ b/bin/sails-deploy.js
@@ -42,7 +42,7 @@ module.exports = function() {
 
   try {
     // Attempt to run the deploy command
-    module({config: {}}, function(err, result) {
+    module({config: rconf}, function(err, result) {
       // If there were any issues, log them to the console.
       if (err) {
         console.error("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-");


### PR DESCRIPTION
We're currently passing an empty configuration to the sails deploy module. Obviously, we need to pass the actual configuration object.