### PR TITLE
Allows keeping response errors in production mode with sails.config.keepResponseErrors

### DIFF
--- a/lib/hooks/responses/defaults/badRequest.js
+++ b/lib/hooks/responses/defaults/badRequest.js
@@ -34,7 +34,7 @@ module.exports = function badRequest(data, options) {
   // Only include errors in response if application environment
   // is not set to 'production'.  In production, we shouldn't
   // send back any identifying information about errors.
-  if (sails.config.environment === 'production') {
+  if (sails.config.environment === 'production' && sails.config.keepResponseErrors !== true) {
     data = undefined;
   }
 

--- a/lib/hooks/responses/defaults/forbidden.js
+++ b/lib/hooks/responses/defaults/forbidden.js
@@ -31,7 +31,7 @@ module.exports = function forbidden (data, options) {
   // Only include errors in response if application environment
   // is not set to 'production'.  In production, we shouldn't
   // send back any identifying information about errors.
-  if (sails.config.environment === 'production') {
+  if (sails.config.environment === 'production' && sails.config.keepResponseErrors !== true) {
     data = undefined;
   }
 

--- a/lib/hooks/responses/defaults/notFound.js
+++ b/lib/hooks/responses/defaults/notFound.js
@@ -36,7 +36,7 @@ module.exports = function notFound (data, options) {
   // Only include errors in response if application environment
   // is not set to 'production'.  In production, we shouldn't
   // send back any identifying information about errors.
-  if (sails.config.environment === 'production') {
+  if (sails.config.environment === 'production' && sails.config.keepResponseErrors !== true) {
     data = undefined;
   }
 

--- a/lib/hooks/responses/defaults/serverError.js
+++ b/lib/hooks/responses/defaults/serverError.js
@@ -31,7 +31,7 @@ module.exports = function serverError (data, options) {
   // Only include errors in response if application environment
   // is not set to 'production'.  In production, we shouldn't
   // send back any identifying information about errors.
-  if (sails.config.environment === 'production') {
+  if (sails.config.environment === 'production' && sails.config.keepResponseErrors !== true) {
     data = undefined;
   }
 


### PR DESCRIPTION
IMHO the current behavior in response handlers of clearing the body in production mode should be optional, hence the proposed `sails.config.keepResponseErrors` here.

Consider the case of a waterline validation error from a model backing a REST operation, one could return a 400 with a list of validation failures:
```
if (err && err.code === 'E_VALIDATION') {
  return res.badRequest(err.invalidAttributes);
}
```

The docs [here](https://github.com/balderdashy/sails-docs/blob/master/concepts/Custom%20Responses/Custom%20Responses.md#resbadrequestvalidationerrors-redirectto) for `res.badRequest()`  say "For requesters expecting JSON, this response includes the 400 status code and any relevant data sent as validationErrors."  Well, this isn't true -- in production mode response body is cleared regardless of `req.wantsJSON`.

Thoughts?