### PR TITLE
explicitly set fork args before grunt hook

### DIFF
--- a/lib/hooks/grunt/index.js
+++ b/lib/hooks/grunt/index.js
@@ -50,6 +50,11 @@ module.exports = function (sails) {
         taskName = '';
       }
 
+      var execArgs = process.execArgv.slice(0);
+      if(execArgs.indexOf('--debug') !== -1) {
+        execArgs.splice(execArgs.indexOf('--debug'),1)
+      }
+
       // Fork Grunt child process
       var child = ChildProcess.fork(
 
@@ -68,7 +73,8 @@ module.exports = function (sails) {
         // opts to pass to node's `child_process` logic
         {
           silent: true,
-          stdio: 'pipe'
+          stdio: 'pipe',
+          execArgv: execArgs
         }
       );
 


### PR DESCRIPTION

The grunt process is being executed with its parents process arguments (i.e. `--debug`). This in turn causes a EADDRINUSE exception to occur.

Issue 
#2670 

Explanation
https://github.com/balderdashy/sails/issues/2670#issuecomment-92140615