### PR TITLE
added "noBind" option to services to resolve #2791

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -555,7 +555,9 @@ module.exports = function(sails) {
         // Add a reference to the Sails app that loaded the module
         module.sails = sails;
         // Bind all methods to the module context
-        _.bindAll(module);
+        if (!module.noBind) {
+          _.bindAll(module);
+        }
       });
       return cb(null, modules);
     };

--- a/test/integration/fixtures/sampleapp/api/services/BasicService.js
+++ b/test/integration/fixtures/sampleapp/api/services/BasicService.js
@@ -1,0 +1,24 @@
+function MyClass() {
+	this.foo = "Bar";
+}
+
+MyClass.prototype = Object.create({
+	getFoo: function() {
+		return this.foo;
+	}
+});
+
+module.exports = {
+	foo: 'bar',
+	setValue: function(val) {
+		this.val = val;
+	},
+	getValue: function() {
+		return this.val;
+	},
+	getContext: function() {
+		return this;
+	},
+	MyClass: MyClass,
+	Error: Error
+};

--- a/test/integration/fixtures/sampleapp/api/services/NoBindService.js
+++ b/test/integration/fixtures/sampleapp/api/services/NoBindService.js
@@ -1,0 +1,25 @@
+function MyClass() {
+	this.foo = "Bar";
+}
+
+MyClass.prototype = Object.create({
+	getFoo: function() {
+		return this.foo;
+	}
+});
+
+module.exports = {
+	noBind: true,
+	foo: 'bar',
+	setValue: function(val) {
+		this.val = val;
+	},
+	getValue: function() {
+		return this.val;
+	},
+	getContext: function() {
+		return this;
+	},
+	MyClass: MyClass,
+	Error: Error
+};

--- a/test/integration/services.test.js
+++ b/test/integration/services.test.js
@@ -64,22 +64,31 @@ describe('Services ::', function() {
 
 			done();
 		});
+		// this can't be avoided since there's no difference between classes and functions
+		it('should not have member class\'s prototypes overwritten', function(done) {
+			assert(!BasicService.MyClass.prototype.getFoo, "MyClass inside of basic service still has the same prototype");
+			done();
+		});
 	});
-	describe('services containing classes', function() {
+	describe('services with noBind enabled', function() {
+		it('should exist', function(done) {
+			assert.notEqual(typeof NoBindService, "undefined", "Example service was not found!");
+			done();
+		});
 		it('should not have their prototypes overwritten', function(done) {
-			assert(BasicService.MyClass.hasOwnProperty('prototype'), "MyClass does not have its own prototype");
-			assert(BasicService.MyClass.prototype.getFoo, "MyClass inside of basic service doesn't the same prototype");
+			assert(NoBindService.MyClass.hasOwnProperty('prototype'), "MyClass does not have its own prototype");
+			assert(NoBindService.MyClass.prototype.getFoo, "MyClass inside of basic service doesn't the same prototype");
 			done();
 		});
 		it('should be able to instantiate an instance', function(done) {
-			var instance = new BasicService.MyClass();
+			var instance = new NoBindService.MyClass();
 			assert.equal(instance.getFoo(), "Bar", "getFoo method returned bad data");
 
 			done();
 		});
 		it('should be able to use instanceof', function(done) {
-			assert((new Error("sadf")) instanceof BasicService.Error, "Cannot use instanceof to compare against Error in my service");
-			assert((new BasicService.MyClass("sadf")) instanceof BasicService.MyClass, "Instance of MyClass is not instanceof MyClass");
+			assert((new Error("sadf")) instanceof NoBindService.Error, "Cannot use instanceof to compare against Error in my service");
+			assert((new NoBindService.MyClass("sadf")) instanceof NoBindService.MyClass, "Instance of MyClass is not instanceof MyClass");
 			done();
 		});
 	});

--- a/test/integration/services.test.js
+++ b/test/integration/services.test.js
@@ -1,0 +1,87 @@
+/**
+ * Module dependencies
+ */
+var assert	= require('assert'),
+	fs		= require('fs'),
+	wrench	= require('wrench'),
+	exec	= require('child_process').exec,
+	_		= require('lodash'),
+	appHelper = require('./helpers/appHelper'),
+	util	= require('util');
+
+
+/**
+ * Module errors
+ */
+
+describe('Services ::', function() {
+	var appName = 'testApp',
+		sailsprocess;
+
+
+	// before we start tests, build the app
+	before(function(done) {
+		this.timeout(5000);
+		appHelper.build(done);
+	});
+
+	// once we're done, remove the app
+	after(function() {
+		process.chdir('../');
+		appHelper.teardown();
+	});
+
+	// before each test, start the app up fresh
+	beforeEach(function(done) {
+		// this.timeout(5000);
+		appHelper.lift({
+			verbose: false
+		}, function(err, sails) {
+			if (err) {
+				throw new Error(err);
+			}
+			sailsprocess = sails;
+			sailsprocess.once('hook:http:listening', done);
+		});
+	});
+
+	// and after each test kill the process
+	afterEach(function(done) {
+		this.timeout(5000);
+		sailsprocess.kill(done);
+	});
+
+	describe('basic services', function() {
+		it('should exist', function(done) {
+			assert.notEqual(typeof BasicService, "undefined", "Example service was not found!");
+			done();
+		});
+		it('should have its methods bound to the services context', function(done) {
+			assert.equal(BasicService, BasicService.getContext.apply({}), "Returning 'this' from a service method does not return that service");
+
+			BasicService.setValue("foo");
+			assert.equal(BasicService.getValue(), "foo", "Setting a value onto 'this' and then reading it back does not result in the same value");
+
+			done();
+		});
+	});
+	describe('services containing classes', function() {
+		it('should not have their prototypes overwritten', function(done) {
+			assert(BasicService.MyClass.hasOwnProperty('prototype'), "MyClass does not have its own prototype");
+			assert(BasicService.MyClass.prototype.getFoo, "MyClass inside of basic service doesn't the same prototype");
+			done();
+		});
+		it('should be able to instantiate an instance', function(done) {
+			var instance = new BasicService.MyClass();
+			assert.equal(instance.getFoo(), "Bar", "getFoo method returned bad data");
+
+			done();
+		});
+		it('should be able to use instanceof', function(done) {
+			assert((new Error("sadf")) instanceof BasicService.Error, "Cannot use instanceof to compare against Error in my service");
+			assert((new BasicService.MyClass("sadf")) instanceof BasicService.MyClass, "Instance of MyClass is not instanceof MyClass");
+			done();
+		});
+	});
+});
+


### PR DESCRIPTION
As per #2791, you cannot store classes in services since it automatically binds all the methods in the service to the service's context. This breaks the class system, obviously.

Since there's no way to programatically detect the intention of a function, either class or real function, we can't fix this is a seamless automatic way. Instead I added a new flag, "noBind", to use in those weird hyper specific corner cases such as this.

Test cases included.