### PR TITLE
update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,12 +100,7 @@
     "type": "git",
     "url": "git://github.com/balderdashy/sails.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://links.sailsjs.org/license/mit"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "http://github.com/balderdashy/sails/issues"
   },


### PR DESCRIPTION
using `licenses` is deprecated from npm@2.10

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/