### PR TITLE
Stop OPTIONS requests over socket.io from crashing Sails

### DIFF
--- a/lib/router/res.js
+++ b/lib/router/res.js
@@ -317,7 +317,7 @@ module.exports = function buildResponse (req, _res) {
   res.set = function (headerName, value) {
     res.headers = res.headers || {};
     res.headers[headerName] = value;
-    return value;
+    return this;
   };
 
   /**


### PR DESCRIPTION
There seems to be a fairly critical bug where you can bring down a Sails instance by emitting a simple OPTIONS request over the socket.io REST interface (see the commit message for a more detailed description).

Steps to reproduce:

In a terminal:
```bash
$ sails new killme
$ cd killme
$ sails lift
```

In a browser's JS console (on localhost:1337):
```
> io.socket.request({method: 'options', url: '/anUndefinedRoute'});
```