### PR TITLE
Add .get() and .header() to MockReq

### DIFF
--- a/lib/router/req.js
+++ b/lib/router/req.js
@@ -56,6 +56,18 @@ module.exports = function buildRequest (_req) {
       url: _req && _req.url
     });
 
+    // Add .get() and .header() methods to match express 3
+    req.get = req.header = function (name) {
+      switch (name = name.toLowerCase()) {
+      case 'referer':
+      case 'referrer':
+        return this.headers.referrer
+          || this.headers.referer;
+      default:
+        return this.headers[name];
+      }
+    };
+
     // Now pump client request body to the mock IncomingMessage stream (req)
     // Req stream ends automatically if this is a GET or HEAD or DELETE request
     // (since there is no request body in that case) so no need to do it again.


### PR DESCRIPTION
These are methods in Express 3, and should be on the mock request for
consistency.