### PR TITLE
Added viewFolder option in res.locals.

### DIFF
--- a/lib/hooks/views/res.view.js
+++ b/lib/hooks/views/res.view.js
@@ -182,6 +182,14 @@ module.exports = function _addResViewMethod(req, res, next) {
       layout = res.locals.layout;
     }
 
+    // Add viewFolder if provided
+    if (typeof res.locals.viewFolder !== 'undefined') {
+      relPathToView = path.join(res.locals.viewFolder, relPathToView);
+      if (typeof layout === 'string') {
+        layout = path.join(res.locals.viewFolder, layout);
+      }
+    }
+
     var pathToViews = sails.config.paths.views;
     var absPathToView = path.join(pathToViews, relPathToView);
     var absPathToLayout;


### PR DESCRIPTION
This is useful when you want to have multiple views for a controller and you want to dynamically switch between them just by specifying a viewFolder.
Typical usage would be to render different views for different devices especially if the device doesn't support RWD.