### PR TITLE
Get npm version fix

### DIFF
--- a/lib/preinstall_npmcheck.js
+++ b/lib/preinstall_npmcheck.js
@@ -1,34 +1,39 @@
-/* Npm Preinstall Script
-* This Script checks if the installed npm-Version matches the 'engine'-Item in package.json
+/**
+ * npm pre-install script.
+ *
+ * This script checks if the installed npm-version matches the required engine
+ * defined in the package.json.
  */
 
-var child_process = require('child_process'),
-    required_npm_version = require('./../package.json').engines.npm;
+
+/**
+ * [exec description]
+ * @type {[type]}
+ */
+var exec = require('child_process').exec;
+var requiredVersion = require('./../package.json').engines.npm;
 
 
-/*
+
+/**
  * Execute 'npm -v' and give back result
  * @param {callback} cb - callback-function(err,version)
  */
 
 var getNpmVersion = function(cb) {
+  exec('npm -v', function (err, stdout) {
+    if (err) return cb(err);
 
-    child_process.exec('npm -v', function (err, stdout) {
+    // remove whitespaces
+    stdout = stdout.replace(/\s+/g, '');
 
-        if(err){
-            return cb(err);
-        }
+    // Check if version-number given back
+    if (!/^[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}$/.test(stdout)) {
+      return cb('Unexpected output');
+    }
 
-        // remove whitespaces
-        stdout = stdout.replace(/\s+/g, '');
-
-        // Check if version-number given back
-        if(!/^[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}$/.test(stdout)){
-            return cb('Unexpected output');
-        }
-
-        return cb(null,stdout);
-    });
+    return cb(null,stdout);
+  });
 };
 
 /*
@@ -40,75 +45,74 @@ var getNpmVersion = function(cb) {
  */
 var checkVersion = function(v,v2) {
 
-    // Delete all unnecessary strings and make arrays
-    v = v.replace(/(\s+)|([^(0-9\.)])/g,'').split('.');
-    v2 = v2.replace(/(\s+)|([^(0-9\.)])/g,'').split('.');
+  // Delete all unnecessary strings and make arrays
+  v = v.replace(/(\s+)|([^(0-9\.)])/g,'').split('.');
+  v2 = v2.replace(/(\s+)|([^(0-9\.)])/g,'').split('.');
 
-    if(v.length != 3 || !v2.length){
-        return false;
+  if (v.length != 3 || !v2.length) {
+    return false;
+  }
+
+  // Fill with 0 if necessary
+  if (v2.length < 3) {
+    if (v2.length == 2) {
+      v2.push([0]);
+    } else {
+      v2.push([0,0]);
     }
+  }
 
-    // Fill with 0 if necessary
-    if(v2.length < 3) {
-        if(v2.length == 2){
-            v2.push([0]);
-        }else{
-            v2.push([0,0]);
-        }
+  var found;
+  v.forEach(function(item,key) {
+    if (found === undefined) {
+
+      if (item > v2[key]) {
+        found = true;
+      } else if (item < v2[key]) {
+        found = false;
+      }
 
     }
+  });
 
-    var found;
-    v.forEach(function(item,key) {
-        if(found === undefined){
-
-            if(item > v2[key]) {
-                found = true;
-            }else if(item < v2[key]) {
-                found = false;
-            }
-
-        }
-    });
-
-    return found;
+  return found;
 
 };
 
 
 getNpmVersion(function(err,version){
-    
-    // If no npm found at 'engine'-Item in package.json
-    if(required_npm_version === undefined){
-        return process.exit(0);
-    }
-
-    if(err){
-        console.log('\033[31mSails.js Installation - Error');
-        console.log('--------------------------------------------------------\033[00m');
-        console.log('Unable to check your npm-version');
-        console.log('');
-        console.log('Please reinstall npm to use Sails.js');
-        console.log('\033[31m--------------------------------------------------------');
-        return process.exit(1);
-    }
-
-
-    // If installed Version to old
-    if(!checkVersion(version,required_npm_version)){
-        console.log('\033[31mSails.js Installation - Error');
-        console.log('--------------------------------------------------------\033[00m');
-        console.log('Your npm-Version is too old:');
-        console.log('Sails require npm ' +required_npm_version+ ' (you currently have '+ version +')');
-        console.log('');
-        console.log('Please update the installed npm (Node Package Manager)');
-        console.log(' to install Sails.');
-        console.log('\033[31m--------------------------------------------------------');
-        return process.exit(1);
-    }
-
-    console.log('Sails.js Installation: Checking npm-version successful');
+  
+  // If no npm found at 'engine'-Item in package.json
+  if (requiredVersion === undefined) {
     return process.exit(0);
+  }
+
+  if (err) {
+    console.log('\033[31mSails.js Installation - Error');
+    console.log('--------------------------------------------------------\033[00m');
+    console.log('Unable to check your npm-version');
+    console.log('');
+    console.log('Please reinstall npm to use Sails.js');
+    console.log('\033[31m--------------------------------------------------------');
+    return process.exit(1);
+  }
+
+
+  // If installed Version to old
+  if(!checkVersion(version,requiredVersion)){
+    console.log('\033[31mSails.js Installation - Error');
+    console.log('--------------------------------------------------------\033[00m');
+    console.log('Your npm-Version is too old:');
+    console.log('Sails require npm ' +requiredVersion+ ' (you currently have '+ version +')');
+    console.log('');
+    console.log('Please update the installed npm (Node Package Manager)');
+    console.log(' to install Sails.');
+    console.log('\033[31m--------------------------------------------------------');
+    return process.exit(1);
+  }
+
+  console.log('Sails.js Installation: Checking npm-version successful');
+  return process.exit(0);
 
 });
 

--- a/lib/preinstall_npmcheck.js
+++ b/lib/preinstall_npmcheck.js
@@ -17,7 +17,7 @@ if (project.engines && project.engines.npm) exec('npm -v', validateNpmVersion);
  * @param  err    Possible command execution error.
  * @param  stdout Command execution result.
  */
-function validateNpmVersion (err, stdout) {
+function validateNpmVersion(err, stdout) {
 
   // Throw-up process errors.
   if (err) return exitWithMessage(err);

--- a/lib/preinstall_npmcheck.js
+++ b/lib/preinstall_npmcheck.js
@@ -5,114 +5,116 @@
  * defined in the package.json.
  */
 
-
-/**
- * [exec description]
- * @type {[type]}
- */
 var exec = require('child_process').exec;
-var requiredVersion = require('./../package.json').engines.npm;
+var project = require('./../package.json');
 
 
+// Validate npm version before installing Sails.
+if (project.engines && project.engines.npm) exec('npm -v', validateNpmVersion);
 
 /**
- * Execute 'npm -v' and give back result
- * @param {callback} cb - callback-function(err,version)
+ * Callback for the 'npm -v' execution.
+ * @param  err    Possible command execution error.
+ * @param  stdout Command execution result.
  */
+function validateNpmVersion (err, stdout) {
 
-var getNpmVersion = function(cb) {
-  exec('npm -v', function (err, stdout) {
-    if (err) return cb(err);
+  // Throw-up process errors.
+  if (err) return exitWithMessage(err);
 
-    // remove whitespaces
-    stdout = stdout.replace(/\s+/g, '');
+  // Parse Semver for current and required.
+  var semver = getSemver(stdout);
+  var requiredNpmSemver = getSemver(project.engines.npm, true);
 
-    // Check if version-number given back
-    if (!/^[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}$/.test(stdout)) {
-      return cb('Unexpected output');
-    }
+  // Get only the release numbering.
+  var version = semver && semver[1];
+  var requiredNpmVersion = requiredNpmSemver && requiredNpmSemver[1];
 
-    return cb(null,stdout);
-  });
-};
+  // If no version is identified, stop install.
+  if (!version) exitWithMessage([
+    'Unable to check your npm-version',
+    '',
+    'Please reinstall npm to use Sails.js'
+  ]);
 
-/*
- * Check if version of first parameter >= version of 2nd parameter
- * ATTENTION: Only support '>='
- * @param {string} v - Version to check (e.g. '10.5.2')
- * @param {string} v2 - Version to check against (e.g. '0.8.14')
- * @return {boolean}
- */
-var checkVersion = function(v,v2) {
-
-  // Delete all unnecessary strings and make arrays
-  v = v.replace(/(\s+)|([^(0-9\.)])/g,'').split('.');
-  v2 = v2.replace(/(\s+)|([^(0-9\.)])/g,'').split('.');
-
-  if (v.length != 3 || !v2.length) {
-    return false;
-  }
-
-  // Fill with 0 if necessary
-  if (v2.length < 3) {
-    if (v2.length == 2) {
-      v2.push([0]);
-    } else {
-      v2.push([0,0]);
-    }
-  }
-
-  var found;
-  v.forEach(function(item,key) {
-    if (found === undefined) {
-
-      if (item > v2[key]) {
-        found = true;
-      } else if (item < v2[key]) {
-        found = false;
-      }
-
-    }
-  });
-
-  return found;
-
-};
-
-
-getNpmVersion(function(err,version){
-  
-  // If no npm found at 'engine'-Item in package.json
-  if (requiredVersion === undefined) {
-    return process.exit(0);
-  }
-
-  if (err) {
-    console.log('\033[31mSails.js Installation - Error');
-    console.log('--------------------------------------------------------\033[00m');
-    console.log('Unable to check your npm-version');
-    console.log('');
-    console.log('Please reinstall npm to use Sails.js');
-    console.log('\033[31m--------------------------------------------------------');
-    return process.exit(1);
-  }
-
-
-  // If installed Version to old
-  if(!checkVersion(version,requiredVersion)){
-    console.log('\033[31mSails.js Installation - Error');
-    console.log('--------------------------------------------------------\033[00m');
-    console.log('Your npm-Version is too old:');
-    console.log('Sails require npm ' +requiredVersion+ ' (you currently have '+ version +')');
-    console.log('');
-    console.log('Please update the installed npm (Node Package Manager)');
-    console.log(' to install Sails.');
-    console.log('\033[31m--------------------------------------------------------');
-    return process.exit(1);
-  }
+  // Handle old npm installations.
+  if (!satisfiesVersion(version, requiredNpmVersion)) exitWithMessage([
+    'Your current npm version (' + version + ') is not supported:',
+    'Sails requires at least version ' + project.engines.npm,
+    '',
+    'Try uploading npm before installing Sails.'
+  ]);
 
   console.log('Sails.js Installation: Checking npm-version successful');
-  return process.exit(0);
 
-});
+  // Exit process with success.
+  process.exit(0);
+}
 
+/**
+ * Exit proccess with a given error beautifully.
+ */
+function exitWithMessage(err, code) {
+
+  // Exit error header.
+  console.log('\033[31mSails.js Installation - Error');
+  console.log('--------------------------------------------------------\033[00m');
+
+  // Exit (possibly multiple) error lines.
+  (typeof err === 'string' ? [err] : err).forEach(function (err) {
+    console.log(err);
+  });
+
+  // Exit error footer.
+  console.log('\033[31m--------------------------------------------------------');
+
+  // Exit processing with a 1 (error) default code.
+  process.exit(code === undefined ? 1 : code);
+}
+
+/**
+ * Parse version string into semver array.
+ * @param {string} version
+ * @param {boolean} range If version is a range, make sure to consider up-front
+ *                        specification.
+ * @return {Array}  An array with the version's parts or null if not valid.
+ */
+function getSemver(version, range) {
+
+  // Fulfil possibly missing zeros, if range is allowed.
+  if (range) {
+    version = version.split('.');
+    var missing = 3 - version.length;
+
+    for(;missing > 0; missing--) {
+      version.push(0);
+    }
+
+    version = version.join('.');
+  }
+
+  var versionRegex = '(([0-9]{1,})\.([0-9]{1,})\.([0-9]{1,}))(?:-?(.*))';
+  var regex = new RegExp('^' + (range ? '(?:.*)' : '') + versionRegex + '$');
+
+  return version.replace(/\s+/g, '').match(regex);
+}
+
+/**
+ * Makes a simple '>=' version comparison.
+ * @param  {string} version
+ * @param  {string} compare
+ * @return {boolean}
+ */
+function satisfiesVersion(version, compare) {
+  var version = version.split('.');
+  var compare = compare.split('.');
+  var satisfied;
+
+  return compare.every(function (value, i) {
+    if (satisfied !== undefined) return satisfied;
+    if (version[i] > value) return satisfied = true;
+    if (version[i] < value) return satisfied = false;
+
+    return true;
+  }) && satisfied !== false;
+}


### PR DESCRIPTION
Hello,

I was about to install Sails for contribution, and when I tried to run `npm link` I got a "Unrecognized npm version" error. This happened on the preinstall script, and was due to my npm being a prerelease version (1.5.0-alpha-4, which by the way I should update). The npm engine requirement, though, is `>= 1.4.0` which should have resolved correctly... I guess...

Anyway, while fixing this issue I ended up doing a major rewrite of the preinstall script, which did not followed most syntax pattern of other scripts in the project.