### PR TITLE
allow controllers to be added by hooks

### DIFF
--- a/lib/hooks/controllers/index.js
+++ b/lib/hooks/controllers/index.js
@@ -1,38 +1,25 @@
-/**
- * Public dependencies.
- */
-
-var _ = require('lodash'),
-	util = require('sails-util');
-
+var _ = require('lodash');
+var util = require('sails-util');
 
 /**
  * Expose `controllers` hook definition
  */
 module.exports = function(sails) {
 
-	/**
-	 * Private dependencies.
-	 */
 	var onRoute = require('./onRoute')(sails);
-
-
 
 	return {
 
 		defaults: {},
 
-		// Don't allow sails to lift until ready
-		// is explicitly set below
+		// Don't allow sails to lift until ready is explicitly set below
 		ready: false,
-
 
 		/**
 		 * Initialize is fired first thing when the hook is loaded
 		 *
 		 * @api public
 		 */
-
 		initialize: function(cb) {
 
 			// Register route syntax for binding controllers.
@@ -45,11 +32,11 @@ module.exports = function(sails) {
     explicitActions: {},
 
 		/**
-		 * Wipe everything and (re)load middleware from controllers
+		 * Wipe everything and (re)load middleware from controllers. Merge any
+     * controllers already defined in the sails.controllers namespace.
 		 *
 		 * @api private
 		 */
-
 		loadAndRegisterControllers: function(cb) {
 			var self = this;
 
@@ -64,7 +51,7 @@ module.exports = function(sails) {
 
 				if (err) return cb(err);
 
-				sails.controllers = modules;
+				sails.controllers = _.merge(sails.controllers || { }, modules);
 
 				// Register controllers
 				_.each(sails.controllers, function(controller, controllerId) {
@@ -74,25 +61,11 @@ module.exports = function(sails) {
 						self.middleware[controllerId] = {};
 					}
 
-					// Mix in middleware from blueprints
-					// ----removed----
-					//
-					// TODO: MAKE SURE THIS IS OK
-					// self.middleware[controllerId].find = Controller.find;
-					// self.middleware[controllerId].create = Controller.create;
-					// self.middleware[controllerId].update = Controller.update;
-					// self.middleware[controllerId].destroy = Controller.destroy;
-					//
-					// -----/removed------
-
-
 					// Register this controller's actions
 					_.each(controller, function(action, actionId) {
 
-
 						// action ids are case insensitive
 						actionId = actionId.toLowerCase();
-
 
 						// If the action is set to `false`, explicitly disable it
 						if (action === false) {
@@ -114,16 +87,12 @@ module.exports = function(sails) {
 						self.middleware[controllerId][actionId] = action;
             self.explicitActions[controllerId] = self.explicitActions[controllerId] || {};
             self.explicitActions[controllerId][actionId] = true;
-
 					});
 
 				});
 
-				// Done!
 				return cb();
 			});
 		}
 	};
-
-
 };


### PR DESCRIPTION
- add controllers to sails.controllers in any hook.configure method and
  the controller definition will be loaded registered just as any bona
  fide controller would
- individual controllers can also be extended by hooks, by adding
  additional properties (actions) to a specific controller.
- cleaned up some extra spaces and old comments

@particlebanana please consider merging into 0.12 RC. Thanks.