### PR TITLE
allow services to be easily extended by hooks

### DIFF
--- a/lib/hooks/controllers/index.js
+++ b/lib/hooks/controllers/index.js
@@ -15,6 +15,10 @@ module.exports = function(sails) {
 		// Don't allow sails to lift until ready is explicitly set below
 		ready: false,
 
+    configure: function () {
+      sails.controllers = { };
+    },
+
 		/**
 		 * Initialize is fired first thing when the hook is loaded
 		 *
@@ -51,7 +55,7 @@ module.exports = function(sails) {
 
 				if (err) return cb(err);
 
-				sails.controllers = _.merge(sails.controllers || { }, modules);
+				sails.controllers = _.merge(sails.controllers, modules);
 
 				// Register controllers
 				_.each(sails.controllers, function(controller, controllerId) {

--- a/lib/hooks/services/index.js
+++ b/lib/hooks/services/index.js
@@ -1,36 +1,23 @@
-/**
- * Module dependencies
- */
-
 var _ = require('lodash');
 
-
-
-
 module.exports = function(sails) {
-
-	/**
-	 * Module loader
-	 *
-	 * Load a module into memory
-	 */
 	return {
-
 
 		// Default configuration
 		defaults: {
-
 			globals: {
 				services: true
 			}
 		},
 
+    configure: function () {
+      sails.services = { };
+    },
 
 		/**
 		 * Fetch relevant modules, exposing them on `sails` subglobal if necessary,
 		 */
 		loadModules: function (cb) {
-
 			sails.log.verbose('Loading app services...');
 			sails.modules.loadServices(function (err, modules) {
 				if (err) {
@@ -40,11 +27,11 @@ module.exports = function(sails) {
 				}
 
 				// Expose modules on `sails`
-				sails.services = modules;
+				sails.services = _.merge(sails.services, modules);
 
 				// Expose globals (if enabled)
 				if (sails.config.globals.services) {
-					_.each(sails.services,function (service,identity) {
+					_.each(sails.services, function (service, identity) {
 						var globalName = service.globalId || service.identity;
 						global[globalName] = service;
 					});


### PR DESCRIPTION
- initialize sails.controllers namespace in hooks.controllers.configure (see #3083)
- initialize sails.services namespace in hooks.services.configure
- merge services with any pre-defined services
- code style cleanup