### PR TITLE
Allow to set using SSL in http config

### DIFF
--- a/lib/hooks/http/initialize.js
+++ b/lib/hooks/http/initialize.js
@@ -33,12 +33,13 @@ module.exports = function(sails) {
         // Create express server
         var app = sails.hooks.http.app = express();
         app.disable('x-powered-by');
-        // (required by Express 3.x)
-        var usingSSL = sails.config.ssl.key && sails.config.ssl.cert;
 
         // Merge SSL into server options
         var serverOptions = sails.config.http.serverOptions || {};
         _.extend(serverOptions, sails.config.ssl);
+        
+        // (required by Express 3.x)
+        var usingSSL = serverOptions.usingSSL || (sails.config.ssl.key && sails.config.ssl.cert);
 
         // Get the appropriate server creation method for the protocol
         var createServer = usingSSL ?


### PR DESCRIPTION
Allow to set using SSL in sails.config.http.serverOptions