### PR TITLE
update blueprint: prevent updating PK, but leave it for Model lifecycle callbacks

### DIFF
--- a/lib/hooks/blueprints/actions/update.js
+++ b/lib/hooks/blueprints/actions/update.js
@@ -29,17 +29,7 @@ module.exports = function updateOneRecord (req, res) {
   // But omit the blacklisted params (like JSONP callback param, etc.)
   var values = actionUtil.parseValues(req);
 
-  // Omit the path parameter `id` from values, unless it was explicitly defined
-  // elsewhere (body/query):
-  var idParamExplicitlyIncluded = ((req.body && req.body.id) || req.query.id);
-  if (!idParamExplicitlyIncluded) delete values.id;
-
-  // No matter what, don't allow changing the PK via the update blueprint
-  // (you should just drop and re-add the record if that's what you really want)
-  if (typeof values[Model.primaryKey] !== 'undefined') {
-    sails.log.warn('Cannot change primary key via update blueprint; ignoring value sent for `' + Model.primaryKey + '`');
-  }
-  delete values[Model.primaryKey];
+  values[Model.primaryKey] = pk;
 
   // Find and update the targeted record.
   //

--- a/lib/hooks/blueprints/actions/update.js
+++ b/lib/hooks/blueprints/actions/update.js
@@ -29,6 +29,8 @@ module.exports = function updateOneRecord (req, res) {
   // But omit the blacklisted params (like JSONP callback param, etc.)
   var values = actionUtil.parseValues(req);
 
+  // No matter what, don't allow changing the PK via the update blueprint
+  // (you should just drop and re-add the record if that's what you really want)
   values[Model.primaryKey] = pk;
 
   // Find and update the targeted record.


### PR DESCRIPTION
might crash your connection provider. tested only on sails-mongo.