### PR TITLE
ORM hook: teardown all connections

### DIFF
--- a/lib/hooks/orm/index.js
+++ b/lib/hooks/orm/index.js
@@ -216,7 +216,14 @@ module.exports = function(sails) {
       async.forEach(Object.keys(sails.adapters || {}), function(name, next) {
         var adapter = sails.adapters[name];
         if (adapter.teardown) {
-          adapter.teardown(null, next);
+          async.forEach(_.keys(sails.config.connections), function(connectionId, next) {
+            var connection = sails.config.connections[connectionId];
+            if (connection.adapter === name) {
+              adapter.teardown(connectionId, next);
+            } else {
+              next();
+            }
+          }, next);
         } else {
           next();
         }


### PR DESCRIPTION
sails-mongo adapter, for example, does not actually teardown the db
connection, if conn is null:
https://github.com/balderdashy/sails-mongo/blob/30034f3d927920d9c5ac6d9747fe28581cbda1b1/lib/adapter.js#L133