### PR TITLE
Out of the box support for babel/ES6?

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -98,6 +98,11 @@ module.exports = function(sails) {
           extensions: ['ls'],
           module: 'LiveScript',
           require: 'livescript'
+        },
+        {
+          extensions: ['es6', 'es', 'jsx'],
+          module: 'babel',
+          require: 'babel/register'
         }
       ];
 


### PR DESCRIPTION
Babel supports `[".es6", ".es", ".jsx", ".js"]` file extensions.

Can't include `js` in that list or it will always try to require. But the others should be fine.

Thoughts?