### PR TITLE
[Proposal] Ability to run code on load before doing _anything_ else (re: Add user configurable language support)

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -83,23 +83,30 @@ module.exports = function(sails) {
       //   module: the NPM module name
       //   require: the require statement
       // }
-      var supportedLangs = [
-        {
-          extensions: ['iced','liticed'],
-          module: 'iced-coffee-script',
-          require: 'iced-coffee-script/register'
-        },
-        {
-          extensions: ['coffee','litcoffee'],
-          module: 'coffee-script',
-          require: 'coffee-script/register'
-        },
-        {
-          extensions: ['ls'],
-          module: 'LiveScript',
-          require: 'livescript'
-        }
-      ];
+      var supportedLangs = sails.config.languages;
+
+      if (typeof supportedLangs === 'undefined') {
+        supportedLangs = [
+          {
+            extensions: ['iced','liticed'],
+            module: 'iced-coffee-script',
+            require: 'iced-coffee-script/register',
+            options: false
+          },
+          {
+            extensions: ['coffee','litcoffee'],
+            module: 'coffee-script',
+            require: 'coffee-script/register',
+            options: false
+          },
+          {
+            extensions: ['ls'],
+            module: 'LiveScript',
+            require: 'livescript',
+            options: false
+          }
+        ];
+      }
 
       var detectedLangs = [];
       var detectedExtens = [];
@@ -140,7 +147,11 @@ module.exports = function(sails) {
         detectedExtens = detectedExtens.concat(lang.extensions);
 
         try {
-           require(lang.require);
+          if (lang.options) {
+            require(lang.require)(lang.options);
+          } else {
+            require(lang.require);
+          }
         } catch(e0){
           try {
             require(path.join(localConfig.appPath, 'node_modules/'+lang.require));

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "istanbul": "*",
     "wrench": "~1.5.8",
     "benchmark": "~1.0.0",
-    "microtime": "~1.3.0",
     "expect.js": "~0.3.1",
     "should": "~5.2.0",
     "supertest": "~0.15.0",

--- a/test/benchmarks/sails.load.test.js
+++ b/test/benchmarks/sails.load.test.js
@@ -24,7 +24,7 @@ describe('benchmarks', function () {
 			var sails = new Sails();
 			return cb();
 		});
-		
+
 
 		//
 		// Load
@@ -135,21 +135,21 @@ describe('benchmarks', function () {
 
 /**
  * Run the specified function, capturing time elapsed.
- * 
+ *
  * @param  {[type]}   description [description]
  * @param  {Function} fn          [description]
  * @return {[type]}               [description]
  */
 function benchmark (description, fn) {
-	
+
 	it (description, function (cb) {
 		var self = this;
 
-		var startedAt = self.microtime.now();
+		var startedAt = Date.now();
 		// console.time(description);
 
 		fn.apply(this, [function _callback () {
-			
+
 			var _result = {};
 
 			// If a `comment` or `expected` was provided, harvest it
@@ -157,7 +157,7 @@ function benchmark (description, fn) {
 			self.expected = null;
 			_result.comment = self.comment;
 			self.comment = null;
-			var finishedAt = self.microtime.now();
+			var finishedAt = Date.now();
 			_result.duration = finishedAt - startedAt;
 			_result.benchmark = description;
 
@@ -171,19 +171,19 @@ function benchmark (description, fn) {
 
 /**
  * Use in mocha's `before`
- * 
+ *
  * @this {Array} benchmarks
  * @this {Object} microtime
  */
 function setupBenchmarks() {
-	this.microtime = require('microtime');
+	// this.microtime = require('microtime');
 	this.benchmarks = [];
 }
 
 
 /**
  * Use in mocha's `after`
- * 
+ *
  * @this {Array} benchmarks
  * @this {Object} microtime
  */
@@ -214,7 +214,7 @@ function reportBenchmarks () {
 			(ms < 1*expected/10) ? 'green' :
 			(ms < 3*expected/10) ? 'green' :
 			(ms < 6*expected/10) ? 'cyan' :
-			(ms < threshold) ? 'yellow' : 
+			(ms < threshold) ? 'yellow' :
 			'red';
 
 		ms += 'ms';
@@ -223,7 +223,7 @@ function reportBenchmarks () {
 		// Whether to show expected ms
 		var showExpected = true; // ms >= threshold;
 
-		return memo + '\n ' + 
+		return memo + '\n ' +
 			(result.benchmark+'') + ' :: '.grey + ms +
 
 			// Expected ms provided, and the test took quite a while


### PR DESCRIPTION
@tjwebb @sgress454 @loicsaintroch @mikermcneil 

This PR keeps the current functionality the same for existing users, but allows them to override the default supported languages in `moduleloader`

the `.sailsrc` can now have a `languages` key added that will replace the default supported languages array.

This brings us at least closer to what we wanted all along, It still does not allow the use of `hooks`, but its already been discussed why we need a whole rewrite to fix that.

This is a good stop gap I think.

Thoughts?