### PR TITLE
Supports use of object as population config value

### DIFF
--- a/lib/hooks/blueprints/actionUtil.js
+++ b/lib/hooks/blueprints/actionUtil.js
@@ -35,6 +35,19 @@ module.exports = {
     var aliasFilter = req.param('populate');
     var shouldPopulate = _options.populate;
 
+    // Allow an object to be specified, where the key is the
+    // name of the association attribute, and value is true/false
+    // (true to populate, false to not)
+    if (!aliasFilter && _.isPlainObject(shouldPopulate)) {
+      aliasFilter = _.transform(shouldPopulate, function(result, val, key) {
+        if (val === true) {
+          result.push(key);
+        }
+
+        return result;
+      }, []);
+    }
+
     // Convert the string representation of the filter list to an Array. We
     // need this to provide flexibility in the request param. This way both
     // list string representations are supported:
@@ -55,10 +68,6 @@ module.exports = {
       // Only populate associations if a population filter has been supplied
       // with the request or if `populate` is set within the blueprint config.
       // Population filters will override any value stored in the config.
-      //
-      // Additionally, allow an object to be specified, where the key is the
-      // name of the association attribute, and value is true/false
-      // (true to populate, false to not)
       if (shouldPopulate) {
         var populationLimit =
           _options['populate_'+association.alias+'_limit'] ||


### PR DESCRIPTION
Lets user add a plain javascript object as a config value for populate on a blueprint route, and only populates keys where value is true. Some code comments allude to this as a feature, but does not appear to be currently implemented in master.

If explicit populate params are specified in the request these settings will be ignored.