### PR TITLE
Views hook refactor

### DIFF
--- a/lib/hooks/views/actions.js
+++ b/lib/hooks/views/actions.js
@@ -1,10 +1,4 @@
-/**
- * Module dependencies
- */
-
 var _ = require('lodash');
-
-
 
 /**
  * Load views and generate view-serving middleware for each one
@@ -14,96 +8,85 @@ var _ = require('lodash');
  * @param  {Function} cb
  * @api private
  */
-
 module.exports = function detectAndPrepareViews (sails, hook, cb) {
 
-	glob(function (err, detectedViews) {
-		if (err) return cb(err);
+  glob(function (err, detectedViews) {
+    if (err) return cb(err);
 
-		// Save existence tree in `sails.views` for consumption later
-		sails.views = detectedViews || {};
+    // Save existence tree in `sails.views` for consumption later
+    sails.views = detectedViews || {};
 
-		// Generate view-serving middleware and stow it in `hook.middleware`
-		createMiddleware(detectedViews);
+    // Generate view-serving middleware and stow it in `hook.middleware`
+    createMiddleware(detectedViews);
 
-		cb();
-	});
+    cb();
+  });
 
+  /**
+   * Generates view-serving middleware for each view
+   */
+  function createMiddleware (detectedViews) {
 
-	/**
-	 * Generates view-serving middleware for each view
-	 */
+    // If there are any matching views which don't have an action
+    // create middleware to serve them
+    _.each(detectedViews, function (view, id) {
 
-	function createMiddleware (detectedViews) {
+      // Create middleware for a top-level view
+      if (view === true) {
+        sails.log.silly('Building action for view: ', id);
+        hook.middleware[id] = serveView(id);
+      }
 
-		// If there are any matching views which don't have an action
-		// create middleware to serve them
-		_.each(detectedViews, function (view, id) {
+      // Create middleware for each subview
+      else {
+        hook.middleware[id] = {};
+        for (var subViewId in detectedViews[id]) {
+          sails.log.silly('Building action for view: ', id, '/', subViewId);
+          hook.middleware[id][subViewId] = serveView(id, subViewId);
+        }
+      }
 
-			// Create middleware for a top-level view
-			if (view === true) {
-				sails.log.silly('Building action for view: ', id);
-				hook.middleware[id] = serveView(id);
-			}
+    }, hook);
+  }
 
-			// Create middleware for each subview
-			else {
-				hook.middleware[id] = {};
-				for (var subViewId in detectedViews[id]) {
-					sails.log.silly('Building action for view: ', id, '/', subViewId);
-					hook.middleware[id][subViewId] = serveView(id, subViewId);
-				}
-			}
+  /**
+   * Exits with a tree indicating which views exist
+   */
+  function glob (cb) {
+    // Glob/stat views so we know whether they exist or not
+    sails.modules.statViews(cb);
+  }
 
-		}, hook);
-	}
+  /**
+   * Returns a middleware chain that remembers a view id and
+   * runs simple middleware to template and serve the view file.
+   * Used to serve views w/o controllers
+   *
+   * (This concatenation approach is crucial to allow policies to be bound)
+   *
+   * @param  {[type]} viewId    [description]
+   * @param  {[type]} subViewId [description]
+   * @return {Array}
+   */
+  function serveView (viewId, subViewId) {
 
+    // Save for use in closure
+    // (handle top-level and subview cases)
+    var viewExpression = viewId + (subViewId ? '/' + subViewId : '');
 
-	/**
-	 * Exits with a tree indicating which views exist
-	 */
+    return [function rememberViewId(req, res, next) {
 
-	function glob (cb) {
-		
-		// Glob/stat views so we know whether they exist or not
-		sails.modules.statViews(cb);
-	}
+      // Save reference for view in res.view() middleware
+      // (only needs to happen if subViewId is not set [top-level view])
+      if (viewId) {
+        req.options.view = viewExpression;
+      }
 
+      next();
 
-
-
-
-	/**
-	 * Returns a middleware chain that remembers a view id and
-	 * runs simple middleware to template and serve the view file.
-	 * Used to serve views w/o controllers
-	 *
-	 * (This concatenation approach is crucial to allow policies to be bound)
-	 * 
-	 * @param  {[type]} viewId    [description]
-	 * @param  {[type]} subViewId [description]
-	 * @return {Array}
-	 */
-
-	function serveView (viewId, subViewId) {
-
-		// Save for use in closure
-		// (handle top-level and subview cases)
-		var viewExpression = viewId + (subViewId ? '/' + subViewId : '');
-
-		return [function rememberViewId(req, res, next) {
-
-			// Save reference for view in res.view() middleware
-			// (only needs to happen if subViewId is not set [top-level view])
-			if (viewId) {
-				req.options.view = viewExpression;
-			}
-
-			next();
-
-		}].concat(function serveView(req, res) {
-			res.view();
-		});
-	}
+    }].concat(function serveView(req, res) {
+      res.view();
+    });
+  }
 };
 

--- a/lib/hooks/views/actions.js
+++ b/lib/hooks/views/actions.js
@@ -5,28 +5,23 @@ var _ = require('lodash');
  *
  * @param  {Sails}    sails
  * @param  {Hook}     hook
- * @param  {Function} cb
  * @api private
  */
-module.exports = function detectAndPrepareViews (sails, hook, cb) {
-
-  glob(function (err, detectedViews) {
-    if (err) return cb(err);
+module.exports = function detectAndPrepareViews (sails, hook) {
+  sails.modules.statViews(function (err, detectedViews) {
+    if (err) throw err;
 
     // Save existence tree in `sails.views` for consumption later
     sails.views = detectedViews || {};
 
     // Generate view-serving middleware and stow it in `hook.middleware`
     createMiddleware(detectedViews);
-
-    cb();
   });
 
   /**
    * Generates view-serving middleware for each view
    */
   function createMiddleware (detectedViews) {
-
     // If there are any matching views which don't have an action
     // create middleware to serve them
     _.each(detectedViews, function (view, id) {
@@ -45,16 +40,7 @@ module.exports = function detectAndPrepareViews (sails, hook, cb) {
           hook.middleware[id][subViewId] = serveView(id, subViewId);
         }
       }
-
-    }, hook);
-  }
-
-  /**
-   * Exits with a tree indicating which views exist
-   */
-  function glob (cb) {
-    // Glob/stat views so we know whether they exist or not
-    sails.modules.statViews(cb);
+    });
   }
 
   /**
@@ -69,24 +55,22 @@ module.exports = function detectAndPrepareViews (sails, hook, cb) {
    * @return {Array}
    */
   function serveView (viewId, subViewId) {
-
     // Save for use in closure
     // (handle top-level and subview cases)
     var viewExpression = viewId + (subViewId ? '/' + subViewId : '');
 
-    return [function rememberViewId(req, res, next) {
-
-      // Save reference for view in res.view() middleware
-      // (only needs to happen if subViewId is not set [top-level view])
-      if (viewId) {
-        req.options.view = viewExpression;
+    return [
+      function rememberViewId(req, res, next) {
+        // Save reference for view in res.view() middleware
+        // (only needs to happen if subViewId is not set [top-level view])
+        if (viewId) {
+          req.options.view = viewExpression;
+        }
+        next();
+      },
+      function serveView(req, res) {
+        res.view();
       }
-
-      next();
-
-    }].concat(function serveView(req, res) {
-      res.view();
-    });
+    ];
   }
 };
-

--- a/lib/hooks/views/configure.js
+++ b/lib/hooks/views/configure.js
@@ -1,13 +1,7 @@
-/**
- * Module dependencies
- */
-
-var _ = require('lodash')
-  , path    = require('path')
-  , util    = require('util')
-  , consolidate   = require('consolidate');
-
-
+var _ = require('lodash');
+var path = require('path');
+var util = require('util');
+var consolidate = require('consolidate');
 
 /**
  * Marshal relevant parts of sails global configuration,
@@ -15,7 +9,6 @@ var _ = require('lodash')
  *
  * @param  {Sails} sails
  */
-
 module.exports = function configure ( sails ) {
 
   if (sails.config.viewEngine) {
@@ -25,10 +18,10 @@ module.exports = function configure ( sails ) {
   }
 
   // Normalize view engine config and allow defining a custom extension
-  if (typeof sails.config.views.engine === 'string') {
+  if (_.isString(sails.config.views.engine)) {
     var viewExt = sails.config.views.extension || sails.config.views.engine;
     sails.config.views.engine = {
-            name: sails.config.views.engine,
+      name: sails.config.views.engine,
       ext: viewExt
     };
   }
@@ -55,10 +48,7 @@ module.exports = function configure ( sails ) {
     var appDependenciesPath;
     var fn;
 
-    appDependenciesPath = path.join(
-      sails.config.appPath,
-      'node_modules'
-    );
+    appDependenciesPath = path.join(sails.config.appPath, 'node_modules');
 
     try {
 
@@ -86,7 +76,6 @@ module.exports = function configure ( sails ) {
     sails.config.views.engine.fn = fn;
     sails.log.silly('Configured view engine, `' + engineName + '`');
   }
-
 
   // Let user know that a leading . is not required in the viewEngine option and then fix it
   if (sails.config.views.engine.ext[0] === '.') {
@@ -126,8 +115,8 @@ function getEngine(appDependenciesPath,engineName,moduleName) {
   var fn = consolidate[engineName];
 
   // If we haven't cached the engine module in consolidate's requires cache, do it now.
-  if(!consolidate.requires[moduleName]){
-    try{
+  if(!consolidate.requires[moduleName]) {
+    try {
       //ensure the engine is required relative to the path of our app
       consolidate.requires[moduleName] = require(appDependenciesPath+'/' + moduleName);
       // If the engine name and module names are different, cache the engine under both
@@ -137,11 +126,10 @@ function getEngine(appDependenciesPath,engineName,moduleName) {
       if (engineName != moduleName) {
         consolidate.requires[engineName] = consolidate.requires[moduleName];
       }
-    }catch(e){
-      console.log(['Could not find module:',moduleName,"in path:",appDependenciesPath].join(" "));
+    } catch(e) {
+      sails.log.info('Could not find module:', moduleName , 'in path:', appDependenciesPath);
     }
   }
 
   return fn;
-
 }

--- a/lib/hooks/views/index.js
+++ b/lib/hooks/views/index.js
@@ -1,12 +1,11 @@
-var async = require('async')
-  , _ = require('lodash')
-  , configure = require('./configure')
-  , defaults  = require('./defaults')
-  , onRoute = require('./onRoute')
-  , addLayoutShim = require('./layoutshim')
-  , addResViewMethod = require('./res.view')
-  , render = require('./render')
-  , implicitActions = require('./actions');
+var _ = require('lodash');
+var configure = require('./configure');
+var defaults = require('./defaults');
+var onRoute = require('./onRoute');
+var addLayoutShim = require('./layoutshim');
+var addResViewMethod = require('./res.view');
+var render = require('./render');
+var implicitActions = require('./actions');
 
 module.exports = function (sails) {
 
@@ -45,9 +44,9 @@ module.exports = function (sails) {
 
         // But wait until after internationalization has happened
         // (if applicable)
-        if ( sails.hooks.i18n ) {
+        if (sails.hooks.i18n) {
           sails.after('hook:i18n:loaded', function () {
-            sails.router.bind('/*', addResViewMethod, 'all', {});
+            sails.router.bind('/*', addResViewMethod, 'all', { });
           });
         }
         else {
@@ -60,18 +59,15 @@ module.exports = function (sails) {
 
       // Declare hook loaded when ejs layouts have been applied,
       // views have been inventoried, and view-serving middleware has been prepared
-      async.auto({
+      addLayoutShim(sails);
 
-        Layouts: _.partial(addLayoutShim, sails),
-
-        // Detect and prepare implicit actions
-        // for each view file so they can be routed to
-        // using {view:'...'} syntax in `routes.js`
-        implicitActions: _.partial(implicitActions, sails, this)
-
-      }, cb);
+      // Detect and prepare implicit actions
+      // for each view file so they can be routed to
+      // using {view:'...'} syntax in `routes.js`
+      implicitActions(sails, this);
 
       sails.renderView = this.render;
+      cb();
     }
   };
 };

--- a/lib/hooks/views/index.js
+++ b/lib/hooks/views/index.js
@@ -1,44 +1,35 @@
-/**
- * Module dependencies.
- */
-
-var async			= require('async')
-	,	_ = require('lodash')
-	,	configure = require('./configure')
-	, defaults  = require('./defaults')
-	,	onRoute = require('./onRoute')
-	, addLayoutShim = require('./layoutshim')
-	, addResViewMethod = require('./res.view')
-	, render = require('./render')
-	, implicitActions = require('./actions');
-
+var async = require('async')
+  , _ = require('lodash')
+  , configure = require('./configure')
+  , defaults  = require('./defaults')
+  , onRoute = require('./onRoute')
+  , addLayoutShim = require('./layoutshim')
+  , addResViewMethod = require('./res.view')
+  , render = require('./render')
+  , implicitActions = require('./actions');
 
 module.exports = function (sails) {
 
-	/**
-	 * `views` hook
-	 *
-	 */
+  /**
+   * `views` hook
+   */
+  return {
 
-	return {
+    defaults: defaults,
 
-		defaults: defaults,
+    configure: _.partial(configure, sails),
 
-		configure: _.partial(configure, sails),
+    render: render,
 
-		render: render,
+    /**
+     * Standard responsibilities of `initialize` are to load middleware methods
+     * and listen for events to know when to bind any special routes.
+     *
+     * @api private
+     */
+    initialize: function (cb) {
 
-		/**
-		 * Standard responsibilities of `initialize` are to load middleware methods
-		 * and listen for events to know when to bind any special routes.
-		 *
-		 * @api private
-		 */
-
-		initialize: function (cb) {
-
-      if ( !sails.hooks.http ) {
-
+      if (!sails.hooks.http) {
         var err = new Error();
         err.message = '`views` hook requires the `http` hook, but the `http` hook is disabled.  Please enable both or neither.';
         err.type = err.code = 'E_HOOKINIT_DEP';
@@ -49,39 +40,38 @@ module.exports = function (sails) {
 
       addResViewMethod._middlewareType = 'VIEWS HOOK: addResViewMethod';
 
-			// Add res.view() method to compatible middleware
-			sails.on('router:before', function () {
+      // Add res.view() method to compatible middleware
+      sails.on('router:before', function () {
 
-				// But wait until after internationalization has happened
-				// (if applicable)
-				if ( sails.hooks.i18n ) {
-					sails.after('hook:i18n:loaded', function () {
+        // But wait until after internationalization has happened
+        // (if applicable)
+        if ( sails.hooks.i18n ) {
+          sails.after('hook:i18n:loaded', function () {
             sails.router.bind('/*', addResViewMethod, 'all', {});
           });
-				}
-				else {
-					sails.router.bind('/*', addResViewMethod, 'all');
-				}
-			});
+        }
+        else {
+          sails.router.bind('/*', addResViewMethod, 'all');
+        }
+      });
 
-			// Register `{view:'/foo'}` route syntax
-			sails.on('route:typeUnknown', _.partial(onRoute, sails));
+      // Register `{view:'/foo'}` route syntax
+      sails.on('route:typeUnknown', _.partial(onRoute, sails));
 
-			// Declare hook loaded when ejs layouts have been applied,
-			// views have been inventoried, and view-serving middleware has been prepared
-			async.auto({
+      // Declare hook loaded when ejs layouts have been applied,
+      // views have been inventoried, and view-serving middleware has been prepared
+      async.auto({
 
-				Layouts: _.partial(addLayoutShim, sails),
+        Layouts: _.partial(addLayoutShim, sails),
 
-				// Detect and prepare implicit actions
-				// for each view file so they can be routed to
-				// using {view:'...'} syntax in `routes.js`
-				implicitActions: _.partial(implicitActions, sails, this)
+        // Detect and prepare implicit actions
+        // for each view file so they can be routed to
+        // using {view:'...'} syntax in `routes.js`
+        implicitActions: _.partial(implicitActions, sails, this)
 
-			}, cb);
+      }, cb);
 
-			sails.renderView = this.render;
-		}
-	};
-
+      sails.renderView = this.render;
+    }
+  };
 };

--- a/lib/hooks/views/layoutshim.js
+++ b/lib/hooks/views/layoutshim.js
@@ -1,9 +1,4 @@
-/**
- * Module dependencies
- */
-
 var path = require('path');
-
 
 /**
  * Implement EJS layouts (a la Express 2)
@@ -16,50 +11,49 @@ var path = require('path');
  * @param  {Sails}   sails
  * @param  {Function} cb
  */
-
 module.exports = function layoutshim (sails, cb) {
 
-	// If layout config is set, attempt to use view partials/layout
-	if (sails.config.views.layout) {
+  // If layout config is set, attempt to use view partials/layout
+  if (sails.config.views.layout) {
 
-		// If `http` hook is not enabled, we can't use partials
-		// (depends on express atm)
-		if (sails.config.hooks.http) {
+    // If `http` hook is not enabled, we can't use partials
+    // (depends on express atm)
+    if (sails.config.hooks.http) {
 
       // Get the view engine name
       var engineName = sails.config.views.engine.name || sails.config.views.engine.ext;
 
-			// Use ejs-locals for all ejs templates
-			if (engineName === 'ejs') {
+      // Use ejs-locals for all ejs templates
+      if (engineName === 'ejs') {
 
-				var ejsLayoutEngine = require('ejs-locals');
+        var ejsLayoutEngine = require('ejs-locals');
 
-				// Wait until express is ready, then configure the view engine
-				return sails.after('hook:http:loaded', function () {
-					sails.log.verbose('Overriding ejs engine config with ejslocals to implement layout support...');
-					sails.config.views.engine.fn = ejsLayoutEngine;
-					cb();
-				});
-			}
+        // Wait until express is ready, then configure the view engine
+        return sails.after('hook:http:loaded', function () {
+          sails.log.verbose('Overriding ejs engine config with ejslocals to implement layout support...');
+          sails.config.views.engine.fn = ejsLayoutEngine;
+          cb();
+        });
+      }
 
-			else if (engineName === 'handlebars') {
-				var exphbs = require('express-handlebars');
-				return sails.after('hook:http:loaded', function() {
-					sails.log.verbose('Overriding handlebars engine with express-handlebars to implement layout support...');
-					var hbs = exphbs.create({
-						defaultLayout: path.join('..', (sails.config.views.layout + '.' + (sails.config.views.extension || 'handlebars')) || ''),
-						helpers: sails.config.views.helpers || {},
-						partialsDir: path.join('views', sails.config.views.partials || ''),
-						extname: sails.config.views.extension
-					});
+      else if (engineName === 'handlebars') {
+        var exphbs = require('express-handlebars');
+        return sails.after('hook:http:loaded', function() {
+          sails.log.verbose('Overriding handlebars engine with express-handlebars to implement layout support...');
+          var hbs = exphbs.create({
+            defaultLayout: path.join('..', (sails.config.views.layout + '.' + (sails.config.views.extension || 'handlebars')) || ''),
+            helpers: sails.config.views.helpers || {},
+            partialsDir: path.join('views', sails.config.views.partials || ''),
+            extname: sails.config.views.extension
+          });
 
-					sails.config.views.engine.fn = hbs.engine;
-					cb();
-				});
-			}
+          sails.config.views.engine.fn = hbs.engine;
+          cb();
+        });
+      }
 
-		}
-	}
+    }
+  }
 
-	return cb();
+  return cb();
 };

--- a/lib/hooks/views/layoutshim.js
+++ b/lib/hooks/views/layoutshim.js
@@ -9,9 +9,8 @@ var path = require('path');
  * for other view engines (e.g. hbs)
  *
  * @param  {Sails}   sails
- * @param  {Function} cb
  */
-module.exports = function layoutshim (sails, cb) {
+module.exports = function layoutshim (sails) {
 
   // If layout config is set, attempt to use view partials/layout
   if (sails.config.views.layout) {
@@ -32,7 +31,6 @@ module.exports = function layoutshim (sails, cb) {
         return sails.after('hook:http:loaded', function () {
           sails.log.verbose('Overriding ejs engine config with ejslocals to implement layout support...');
           sails.config.views.engine.fn = ejsLayoutEngine;
-          cb();
         });
       }
 
@@ -48,12 +46,8 @@ module.exports = function layoutshim (sails, cb) {
           });
 
           sails.config.views.engine.fn = hbs.engine;
-          cb();
         });
       }
-
     }
   }
-
-  return cb();
 };


### PR DESCRIPTION
- closes #3041 
- `async` is way overused everywhere. removed occurrence from views hook
- de-fang missing `ejs` module warning
- reformatted to match the rest of the codebase
- use `_.isString` instead of `typeof`