### PR TITLE
add "hookName" option to installable hook config

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -1,23 +1,10 @@
 module.exports = function(sails) {
 
-
-  /**
-   * Module dependencies
-   */
-
   var path = require('path');
   var async = require('async');
   var _ = require('lodash');
   var buildDictionary = require('sails-build-dictionary');
   var walk = require('walk');
-
-
-  // TODO:
-  // Look at improving `includeAll` to work asynchronously
-  // CommonJS `require` is a blocking operation, and makes apps
-  // start slower.
-
-
 
   /**
    * Module loader
@@ -25,9 +12,6 @@ module.exports = function(sails) {
    * Load a module into memory
    */
   return {
-
-
-    // Default configuration
     defaults: function (config) {
 
       var localConfig = {
@@ -158,7 +142,6 @@ module.exports = function(sails) {
       return localConfig;
     },
 
-
     initialize: function(cb) {
       // Expose self as `sails.modules` (for backwards compatibility)
       sails.modules = sails.hooks.moduleloader;
@@ -174,8 +157,6 @@ module.exports = function(sails) {
           this.configure();
         }
       }
-      // console.log('Trying to use appPath:',sails.config.appPath);
-      // console.log('Trying to use config dir at:',path.resolve(sails.config.appPath, 'config'));
       sails.config.appPath = sails.config.appPath ? path.resolve(sails.config.appPath) : process.cwd();
 
       _.extend(sails.config.paths, {
@@ -220,7 +201,6 @@ module.exports = function(sails) {
     loadUserConfig: function (cb) {
 
       async.auto({
-
         'config/*': function loadOtherConfigFiles (cb) {
           buildDictionary.aggregate({
             dirname   : sails.config.paths.config || sails.config.appPath + '/config',
@@ -231,7 +211,6 @@ module.exports = function(sails) {
             identity  : false
           }, cb);
         },
-
 
         'config/local' : function loadLocalOverrideFile (cb) {
           buildDictionary.aggregate({
@@ -290,8 +269,6 @@ module.exports = function(sails) {
       });
     },
 
-
-
     /**
      * Load app controllers
      *
@@ -308,9 +285,6 @@ module.exports = function(sails) {
       }, bindToSails(cb));
     },
 
-
-
-
     /**
      * Load adapters
      *
@@ -325,9 +299,6 @@ module.exports = function(sails) {
         flattenDirectories: true
       }, bindToSails(cb));
     },
-
-
-
 
     /**
      * Load app's model definitions
@@ -357,10 +328,6 @@ module.exports = function(sails) {
       });
     },
 
-
-
-
-
     /**
      * Load app services
      *
@@ -375,8 +342,6 @@ module.exports = function(sails) {
         caseSensitive : true
       }, bindToSails(cb));
     },
-
-
 
     /**
      * Check for the existence of views in the app
@@ -393,8 +358,6 @@ module.exports = function(sails) {
       }, cb);
     },
 
-
-
     /**
      * Load app policies
      *
@@ -410,8 +373,6 @@ module.exports = function(sails) {
         keepDirectoryPath: true
       }, bindToSails(cb));
     },
-
-
 
     /**
      * Load app hooks
@@ -452,7 +413,6 @@ module.exports = function(sails) {
         var hooks = results.hooksFolder;
 
         try {
-
           var modules = flattenNamespacedModules(results.nodeModulesFolder);
 
           _.extend(hooks, _.reduce(modules, function(memo, module, identity) {
@@ -460,12 +420,16 @@ module.exports = function(sails) {
             // Hooks loaded from "node_modules" need to have "sails.isHook: true" in order for us
             // to know that they are a sails hook
             if (module['package.json'] && module['package.json'].sails && module['package.json'].sails.isHook) {
+              var hookConfig = module['package.json'].sails;
 
               // Determine the name the hook should be added as
               var hookName;
 
+              if (!_.isEmpty(hookConfig.hookName)) {
+                hookName = hookConfig.hookName;
+              }
               // If an identity was specified in sails.config.installedHooks, use that
-              if (sails.config.installedHooks && sails.config.installedHooks[identity] && sails.config.installedHooks[identity].name) {
+              else if (sails.config.installedHooks && sails.config.installedHooks[identity] && sails.config.installedHooks[identity].name) {
                 hookName = sails.config.installedHooks[identity].name;
               }
               // Otherwise use the module name, with initial "sails-hook" stripped off if it exists
@@ -512,8 +476,6 @@ module.exports = function(sails) {
       });
     },
 
-
-
     /**
      * Load app blueprint middleware.
      *
@@ -527,8 +489,6 @@ module.exports = function(sails) {
         useGlobalIdForKeyName: true
       }, cb);
     },
-
-
 
     /**
      * Load custom API responses.
@@ -548,7 +508,6 @@ module.exports = function(sails) {
     required: buildDictionary.required,
     aggregate: buildDictionary.aggregate,
     exits: buildDictionary.exists
-
   };
 
   function bindToSails(cb) {


### PR DESCRIPTION
- cleaned up formatting
- set "hookName" in order to specify installable hook name.
e.g.
```
{
  "sails": {
    "isHook": true,
    "hookName": "myHook"
  }
}
```