### PR TITLE
Set useGlobal to true for REPL in sails console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Sails Changelog
 
 ### master
-
+* [ENHANCEMENT] Set the useGlobal config option for REPL while using sails console, allows autoreload hook to reflect changes on global models and services
 * [ENHANCEMENT] Support JSON sorting syntax in blueprints [#2449](https://github.com/balderdashy/sails/issues/2449)
 * [ENHANCEMENT] Support private modules as hooks [#3022](https://github.com/balderdashy/sails/issues/3022)
 * [BUGFIX] Fixed issues with subscribing sockets to new model instances in a clustered environment [#2990](https://github.com/balderdashy/sails/issues/2990), [#3008](https://github.com/balderdashy/sails/issues/3008)

--- a/bin/sails-console.js
+++ b/bin/sails-console.js
@@ -47,7 +47,7 @@ module.exports = function() {
     log.info(('( to exit, type ' + '<CTRL>+<C>' + ' )').grey);
     console.log();
 
-    var repl = REPL.start('sails> ');
+    var repl = REPL.start({prompt: 'sails> ', useGlobal: true});
     try {
       history(repl, nodepath.join(sails.config.paths.tmp, '.node_history'));
     } catch (e) {


### PR DESCRIPTION
This is a minor change that enables the useGlobal config option for REPL when running sails console.

I noticed that when using the sails autoreload hook that the available globals weren't being reloaded.  For example, I created a service called "Init" and when I made a change to my Init.js file, calling sails.services.init reflected the changes I made, but calling Init as a global on the console didn't.

Enabling the useGlobal option makes these changes available on the console when using the autoreload hook.