### PR TITLE
Fix blueprints puralize option

### DIFF
--- a/lib/hooks/blueprints/index.js
+++ b/lib/hooks/blueprints/index.js
@@ -243,15 +243,16 @@ module.exports = function(sails) {
 
 
         // Determine base route
-        var baseRoute = config.prefix + '/' + controllerId;
-        // Determine base route for RESTful service
-        // Note that restPrefix will always start with /
-        var baseRestRoute = config.prefix + config.restPrefix + '/' + controllerId;
+        var baseRouteName = controllerId;
 
         if (config.pluralize) {
-          baseRoute = pluralize(baseRoute);
-          baseRestRoute = pluralize(baseRestRoute);
+          baseRouteName = pluralize(baseRouteName);
         }
+        
+        var baseRoute = config.prefix + '/' + baseRouteName;
+        // Determine base route for RESTful service
+        // Note that restPrefix will always start with /
+        var baseRestRoute = config.prefix + config.restPrefix + '/' + baseRouteName;
 
         // Build route options for blueprint
         var routeOpts = config;

--- a/test/integration/fixtures/sampleapp/api/controllers/QuizController.js
+++ b/test/integration/fixtures/sampleapp/api/controllers/QuizController.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/integration/fixtures/sampleapp/api/models/Quiz.js
+++ b/test/integration/fixtures/sampleapp/api/models/Quiz.js
@@ -1,0 +1,6 @@
+module.exports = {
+	schema: false,
+	attributes: {
+    bar: 'string'
+  }
+};

--- a/test/integration/router.APIScaffold.test.js
+++ b/test/integration/router.APIScaffold.test.js
@@ -203,6 +203,18 @@ describe('router :: ', function() {
         });
       });
 
+      it('should bind blueprint actions to plural controller names (quiz => quizzes)', function(done) {
+        httpHelper.testRoute('get', {
+          url: 'quizzes',
+          json: true
+        }, function(err, response) {
+          if (err) done(new Error(err));
+
+          assert(response.body instanceof Array);
+          done();
+        });
+      });
+
       it('should not bind blueprint actions to singular controller names', function(done) {
         httpHelper.testRoute('get', {
           url: 'empty',

--- a/test/integration/router.APIScaffold.test.js
+++ b/test/integration/router.APIScaffold.test.js
@@ -226,6 +226,18 @@ describe('router :: ', function() {
           done();
         });
       });
+
+      it('should not bind blueprint actions to singular controller names (quiz)', function(done) {
+        httpHelper.testRoute('get', {
+          url: 'quiz',
+          json: true
+        }, function(err, response) {
+          if (err) done(new Error(err));
+
+          assert(response.statusCode === 404);
+          done();
+        });
+      });
     });
 
     describe('with `prefix` option set :: ', function() {


### PR DESCRIPTION
don't call `pluralize('/quiz')` (returns `/quizs`). call `pluralize('quiz')` (returns `quizzes`).