### PR TITLE
Added dependencies status image - take II

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/balderdashy/sails?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![NPM version](https://badge.fury.io/js/sails.svg)](http://badge.fury.io/js/sails)
 [![Build Status](https://api.travis-ci.org/balderdashy/sails.png?branch=master)](https://travis-ci.org/balderdashy/sails)
-
+[![Dependency Status](https://david-dm.org/balderdashy/sails.svg)](https://david-dm.org/balderdashy/sails)
 
 Sails.js is a web framework that makes it easy to build custom, enterprise-grade Node.js apps. It is designed to resemble the MVC architecture from frameworks like Ruby on Rails, but with support for the more modern, data-oriented style of web app development. It's especially good for building realtime features like chat.
 


### PR DESCRIPTION
This is a second PR of the same change. For some reason @mikermcneil just removed previously accepted PR on commit 5c3a23c6e8d4679cf28d3ed153c4fd85274f8155 with comment "removed broken badge". Actual badge isn't broken, only the dependencies that sails uses are outdated.

Imho isn't good policy to "hide" things like this...