### PR TITLE
"Update" blueprint honors model's "populate" configuration

### DIFF
--- a/lib/hooks/blueprints/actions/update.js
+++ b/lib/hooks/blueprints/actions/update.js
@@ -42,7 +42,12 @@ module.exports = function updateOneRecord (req, res) {
   // (Note: this could be achieved in a single query, but a separate `findOne`
   //  is used first to provide a better experience for front-end developers
   //  integrating with the blueprint API.)
-  Model.findOne(pk).populateAll().exec(function found(err, matchingRecord) {
+  var query = Model.findOne(pk);
+
+  // Send a populated model if required
+  if (req.options.populate) query = query.populateAll();
+
+  query.exec(function found(err, matchingRecord) {
 
     if (err) return res.serverError(err);
     if (!matchingRecord) return res.notFound();


### PR DESCRIPTION
Here's a quick fix for: https://github.com/balderdashy/sails/issues/2995, which doesn't return populated models on update if populate was set to false.