### PR TITLE
Really fix #2670

### DIFF
--- a/lib/hooks/grunt/index.js
+++ b/lib/hooks/grunt/index.js
@@ -45,11 +45,6 @@ module.exports = function (sails) {
         taskName = '';
       }
 
-      var execArgs = process.execArgv.slice(0);
-      if(execArgs.indexOf('--debug') !== -1) {
-        execArgs.splice(execArgs.indexOf('--debug'),1);
-      }
-
       // Fork Grunt child process
       var child = ChildProcess.fork(
 
@@ -69,7 +64,11 @@ module.exports = function (sails) {
         {
           silent: true,
           stdio: 'pipe',
-          execArgv: execArgs
+          // pass all current node process arguments to the child process,
+          // except the debug-related arguments, see issue #2670
+          execArgv: process.execArgv.slice(0).filter(function (param) { 
+            return !(new RegExp('--debug(-brk=[0-9]+)?').test(param));
+          });
         }
       );
 

--- a/lib/hooks/grunt/index.js
+++ b/lib/hooks/grunt/index.js
@@ -68,7 +68,7 @@ module.exports = function (sails) {
           // except the debug-related arguments, see issue #2670
           execArgv: process.execArgv.slice(0).filter(function (param) { 
             return !(new RegExp('--debug(-brk=[0-9]+)?').test(param));
-          });
+          })
         }
       );
 


### PR DESCRIPTION
WebStorm IDE passes the ```--debug-brk=<PORTNUM>``` parameter to nodejs,
this breaks grunt hook, because the child nodejs process couldn't bind
the port already bound by current nodejs process.

See #2670 and #2888