### PR TITLE
added support for cassandra as session store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Support CSRF hook route configuration [#2366](https://github.com/balderdashy/sails/issues/2366)
 * [BUGFIX] Fix [RangeError: Maximum call stack size exceeded] error in PubSub hook
 * [ENHANCEMENT] Support layout for Ractive template engine
+* [ENHANCEMENT] added support for cassandra session store
 
 
 ### 0.11.0

--- a/lib/hooks/session/index.js
+++ b/lib/hooks/session/index.js
@@ -93,10 +93,11 @@ module.exports = function(app) {
       // (allow mongo or redis session stores to be specified directly)
       if (app.config.session.adapter === 'redis') {
         app.config.session.adapter = 'connect-redis';
-      }
-      else if (app.config.session.adapter === 'mongo') {
+      } else if (app.config.session.adapter === 'mongo') {
         app.config.session.adapter = 'connect-mongo';
-      }
+      } else if (app.config.session.adapter === 'cassandra') {
+        app.config.session.adapter = 'connect-cassandra-cql';
+	    }
     },
 
     /**
@@ -147,8 +148,7 @@ module.exports = function(app) {
               if (adapter === 'connect-redis') {
                 installRecommendation += 'connect-redis@1.4.5';
                 installRecommendation += '\n(Note that `connect-redis@1.5.0` introduced breaking changes- make sure you have v1.4.5 installed!)';
-              }
-              else {
+              } else {
                 installRecommendation += adapter;
                 installRecommendation +='\n(Note: Make sure the version of the Connect adapter you install is compatible with Express 3/Sails v0.10)';
               }
@@ -174,7 +174,15 @@ module.exports = function(app) {
               }
               var SessionAdapter = require(pathToAdapterDependency);
               var CustomStore = SessionAdapter(require('express'));
-              sessionConfig.store = new CustomStore(sessionConfig);
+
+              if(app.config.session.adapter === 'connect-cassandra-cql'){
+                var cassandra = require('cassandra-driver');
+                var client = new cassandra.Client(sessionConfig);
+                var config = {client: client};
+                sessionConfig.store = new CustomStore(config) ;
+              } else {
+                sessionConfig.store = new CustomStore(sessionConfig);
+              }
             } catch (e) {
               // TODO: negotiate error and give better error msg depending on code
               return cb(COULD_NOT_REQUIRE_CONNECT_ADAPTER_ERR(sessionConfig.adapter, adapterPackage, e));


### PR DESCRIPTION
this code enable the possibility to use cassandra as session store, a pull request with templates modifications is going to be open on sails-generate-backend repository.