### PR TITLE
Update hook.cors_csrf unit test to be compliant with node 4.x.x

### DIFF
--- a/test/integration/hook.cors_csrf.test.js
+++ b/test/integration/hook.cors_csrf.test.js
@@ -86,9 +86,17 @@ describe('CORS and CSRF ::', function() {
             url: 'test',
           }, function(err, response) {
             if (err) return done(new Error(err));
-            var body = response.body.split(',').sort().join(',');
+            var methods = response.body.split(',');
+            var expectedMethods = [
+              'CHECKOUT', 'CONNECT', 'COPY', 'DELETE', 'GET', 'HEAD', 'LOCK',
+              'M-SEARCH', 'MERGE', 'MKACTIVITY', 'MKCOL', 'MOVE', 'NOTIFY',
+              'PATCH', 'POST', 'PROPFIND', 'PROPPATCH', 'PURGE', 'PUT', 'REPORT',
+              'SEARCH', 'SUBSCRIBE', 'TRACE', 'UNLOCK', 'UNSUBSCRIBE'
+            ];
             assert.equal(response.statusCode, 200);
-            assert.equal(body, 'CHECKOUT,CONNECT,COPY,DELETE,GET,HEAD,LOCK,M-SEARCH,MERGE,MKACTIVITY,MKCOL,MOVE,NOTIFY,PATCH,POST,PROPFIND,PROPPATCH,PURGE,PUT,REPORT,SEARCH,SUBSCRIBE,TRACE,UNLOCK,UNSUBSCRIBE', require('util').format('Unexpected HTTP methods:  "%s"', response.body));
+            for (var i in expectedMethods) {
+              assert(methods.indexOf(expectedMethods[i]) !== -1, require('util').format('HTTP method not found:  "%s" in "%s"', expectedMethods[i], response.body));
+            }
             done();
           });
 


### PR DESCRIPTION
The unit test suite didn't pass with node 4.x.x. [The MKCALENDAR http method is now supported](https://github.com/nodejs/http-parser/issues/255) but the test was checking the response of an OPTION request globally.

In this PR, I checked the presence of each http method that should be available for node < 4.x.x.
MKCALENDAR is not tested, but the test suite works successfully with 4.x.x .