### PR TITLE
Add the route options to the "routeObj" emited by the "router:bind" sails event

### DIFF
--- a/lib/EVENTS.md
+++ b/lib/EVENTS.md
@@ -96,7 +96,8 @@ Should receive a single argument, "routeObj", which looks like:
 {
   path: 'String',
   target: function theFnBoundtoTheRoute (req, res, next) {},
-  verb: 'String'
+  verb: 'String',
+  options: 'Object'
 }
 ```
 

--- a/lib/router/bind.js
+++ b/lib/router/bind.js
@@ -311,6 +311,7 @@ function bindFunction(path, fn, verb, options) {
       path: path,
       target: util.clone(targetFn),
       verb: verb,
+      options: options,
       originalFn: fn
     });
 


### PR DESCRIPTION
A small modification to include the route options in the object emitted by the `router:bind` event.

That would be very useful for hooks. It could replace (or maybe be used to implement?) the `sails.getRoutes()` method proposed [in the comments of PR-2659](https://github.com/balderdashy/sails/pull/2659#issuecomment-76107213).

Besides being useful for routing and debugging hooks, it could be used to generate api documentations like [Swagger](http://swagger.io/), [Raml](http://raml.org/) or [API Blueprint](https://apiblueprint.org/). For example, the [sails-swagger](https://github.com/tjwebb/sails-swagger) hook is kind of [reverse engineering the content of `sails.router._privateRouter.routes`](https://github.com/tjwebb/sails-swagger/blob/master/lib/xfmr.js) to find models associated to routes. The task is even more awkward if you have to [retrieve blueprint prefixes](https://github.com/tjwebb/sails-swagger/pull/7) or manage the `blueprints.pluralize` configuration.

Having the possibility to read the route's options when listening at the `router:bind` event would make this task trivial. Example of value retrieved for a rest blueprint route:
```
{ path: '/pet/:id',
  target: [Function: routeTargetFnWrapper],
  verb: 'post',
  options: 
   { associations: [],
     actions: true,
     index: true,
     shortcuts: true,
     rest: true,
     prefix: '',
     restPrefix: '',
     pluralize: false,
     populate: true,
     autoWatch: true,
     model: 'pet',
     action: 'update',
     controller: 'pet',
     detectedVerb: { verb: '', original: '/pet/:id', path: '/pet/:id' },
     skipRegex: [] },
  originalFn: { [Function: updateOneRecord] _middlewareType: 'BLUEPRINT: updateOneRecord' }
}
``` 

Finally, [`options` is already available in the object emitted by the `router:route` event](https://github.com/balderdashy/sails/blob/master/lib/router/bind.js#L165-L171). I think it would make sense to make it available when `router:bind` is fired too.
