### PR TITLE
Preserve context when calling log functions

### DIFF
--- a/lib/app/lower.js
+++ b/lib/app/lower.js
@@ -58,7 +58,6 @@ module.exports = function lower(cb) {
     // Shut down Socket server
     // wait for all attached servers to stop
     sails.emit('lower');
-    var log = sails.log.verbose;
 
     async.series([
 
@@ -68,12 +67,12 @@ module.exports = function lower(cb) {
         }
 
         try {
-          log('Shutting down socket server...');
+          sails.log.verbose('Shutting down socket server...');
           var timeOut = setTimeout(cb, 100);
           sails.io.server.unref();
           sails.io.server.close();
           sails.io.server.on('close', function() {
-            log('Socket server shut down successfully.');
+            sails.log.verbose('Socket server shut down successfully.');
             clearTimeout(timeOut);
             cb();
           });
@@ -89,12 +88,12 @@ module.exports = function lower(cb) {
         }
 
         try {
-          log('Shutting down HTTP server...');
+          sails.log.verbose('Shutting down HTTP server...');
           var timeOut = setTimeout(cb, 100);
           sails.hooks.http.server.unref();
           sails.hooks.http.server.close();
           sails.hooks.http.server.on('close', function() {
-            log('HTTP server shut down successfully.');
+            sails.log.verbose('HTTP server shut down successfully.');
             clearTimeout(timeOut);
             cb();
           });


### PR DESCRIPTION
This fixes a rare issue where the built-in `sails.log` object is overridden with a custom logging implementation which uses functions that depend on a particular value of `this`.

For example, if a `sails.log.verbose()` function is called like this:

```js
var log = sails.log.verbose

log(‘test message’)
```

The value of `this` within this function will be either `undefined` (strict mode) or the `global` object, instead of the expected `sails.log` object.

> For the sake of interest, I have replaced the logger with a [bunyan](https://github.com/trentm/node-bunyan) logger, which is implemented this way.