### PR TITLE
CSRF bypass based on header

### DIFF
--- a/lib/hooks/csrf/index.js
+++ b/lib/hooks/csrf/index.js
@@ -28,7 +28,14 @@ module.exports = function(sails) {
           protectionEnabled: true,
           origin: '-',
           routesDisabled: '-',
-          route: '/csrfToken'
+          route: '/csrfToken',
+          skipHeader: {
+            enabled: false,
+            headerName: 'x-csrf-skip-header',
+            value: function() {
+              return 'CSRF-SKIP'
+            }
+          }
         };
       }
       else if (sails.config.csrf === false) {
@@ -37,7 +44,14 @@ module.exports = function(sails) {
           protectionEnabled: false,
           origin: '-',
           routesDisabled: '-',
-          route: '/csrfToken'
+          route: '/csrfToken',
+          skipHeader: {
+            enabled: false,
+            headerName: 'x-csrf-skip-header',
+            value: function() {
+              return 'CSRF-SKIP'
+            }
+          }
         };
       }
       // If user provides ANY object (including empty object), enable all default
@@ -48,7 +62,14 @@ module.exports = function(sails) {
           protectionEnabled: true,
           origin: '-',
           routesDisabled: '-',
-          route: '/csrfToken'
+          route: '/csrfToken',
+          skipHeader: {
+            enabled: false,
+            headerName: 'x-csrf-skip-header',
+            value: function() {
+              return 'CSRF-SKIP'
+            }
+          }
         });
       }
       // Create a route path for getting _csrf parameter
@@ -97,6 +118,12 @@ module.exports = function(sails) {
 
               if (isRouteDisabled) {
                 return next();
+              } else if (sails.config.csrf.skipHeader
+                  && sails.config.csrf.skipHeader.enabled
+                  && req.headers[sails.config.csrf.skipHeader.headerName]
+                  && req.headers[sails.config.csrf.skipHeader.headerName] == sails.config.csrf.skipHeader.value()
+                ) {
+                  return next();
               } else {
                 // Return an Access-Control-Allow-Origin header in case this is a xdomain request
                 if (req.headers.origin) {


### PR DESCRIPTION
## Method to specify a header to skip CSRF validation

### Use case
We need a way to skip CSRF validation in case API is accessed by a backend system or mobile apps. To ensure that we have a method to specify skipping of CSRF validation using header in request

### Method

```javascript
module.exports.csrf = {
  grantTokenViaAjax: true,
  protectionEnabled: true,
  origin: '-',
  routesDisabled: '-',
  route: '/csrfToken',
  skipHeader: {
    enabled: true,
    headerName: 'x-csrf-skip-header',
    value: function() {
      return 'CSRF-SKIP'
    }
  }
};
```

If CSRF object is set as above then if request contains header as x-csrf-skip-header and value is CSRF-SKIP then request is properly processed.