### PR TITLE
don't send stack track back for body parse errors when environment is production

### DIFF
--- a/lib/hooks/http/middleware/defaults.js
+++ b/lib/hooks/http/middleware/defaults.js
@@ -168,6 +168,9 @@ module.exports = function(sails, app) {
     // is overridden in userland.  Should probably be phased out at some point,
     // since it could be accomplished more elegantly- btu for now it's practical.)
     handleBodyParserError: function handleBodyParserError(err, req, res, next) {
+      if(IS_PRODUCTION){
+        return res.send(400);
+      }
       var bodyParserFailureErrorMsg = 'Unable to parse HTTP body- error occurred :: ' + util.inspect((err&&err.stack)?err.stack:err, false, null);
       sails.log.error(bodyParserFailureErrorMsg);
       return res.send(400, bodyParserFailureErrorMsg);


### PR DESCRIPTION
Not sure what if any tests should be updated for this. 