### PR TITLE
Fix: Check for existence of association alias in pubsub

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -823,7 +823,7 @@ module.exports = function(sails) {
 
             // If it's a to-one association, and it wasn't falsy, alert
             // the reverse side
-            if (association.type == 'model' && [association.alias] && previous[association.alias]) {
+            if (association.type == 'model' && association.alias && previous[association.alias]) {
               ReferencedModel = sails.models[association.model];
               // Get the inverse association definition, if any
               reverseAssociation = _.find(ReferencedModel.associations, {collection: this.identity}) || _.find(ReferencedModel.associations, {model: this.identity});


### PR DESCRIPTION
As far as I can tell, `[association.alias]` is just creating an array with the alias value in it, and even `[undefined]` is truthy, so this will always pass.

Was this meant to check if `association.alias` is defined/truthy before using it in the accessor?