### PR TITLE
expose i18n plural support function globally

### DIFF
--- a/lib/hooks/i18n/index.js
+++ b/lib/hooks/i18n/index.js
@@ -84,6 +84,7 @@ module.exports = function(sails) {
 
 				// Expose global access to locale strings
 				sails.__ = i18n.__;
+        sails.__n = i18n.__n;
 			});
 
 			// Finally


### PR DESCRIPTION
Currently, __n is not visible in templates rendered from an ajax call.