### PR TITLE
Add coverage status for the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/balderdashy/sails?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![NPM version](https://badge.fury.io/js/sails.svg)](http://badge.fury.io/js/sails)
 
+[![Coverage Status](https://coveralls.io/repos/balderdashy/sails/badge.svg?branch=master&service=github)](https://coveralls.io/github/balderdashy/sails?branch=master)
 
 Sails.js is a web framework that makes it easy to build custom, enterprise-grade Node.js apps. It is designed to resemble the MVC architecture from frameworks like Ruby on Rails, but with support for the more modern, data-oriented style of web app development. It's especially good for building realtime features like chat.
 


### PR DESCRIPTION
It's a great idea to add the coverage status of a project in the readme.

At the moment, this is hidden in the [Contributing Guide](https://github.com/balderdashy/sails/blob/master/CONTRIBUTING.md).