### PR TITLE
Fix typo

### DIFF
--- a/bin/sails.js
+++ b/bin/sails.js
@@ -96,7 +96,7 @@ cmd = program.command('consle');
 cmd.unknownOption = NOOP;
 cmd.description('');
 cmd.action(require('./sails-console'));
-cmd = program.command('consloe');
+cmd = program.command('console');
 cmd.unknownOption = NOOP;
 cmd.description('');
 cmd.action(require('./sails-console'));


### PR DESCRIPTION
Simple typo on the word "console"