### PR TITLE
Avoid duplicating work done by npm

### DIFF
--- a/lib/hooks/session/index.js
+++ b/lib/hooks/session/index.js
@@ -124,7 +124,7 @@ module.exports = function(app) {
           // or catch and return error:
           else {
 
-            var COULD_NOT_REQUIRE_CONNECT_ADAPTER_ERR = function (adapter, packagejson, e) {
+            var COULD_NOT_REQUIRE_CONNECT_ADAPTER_ERR = function (adapter, e) {
               var errMsg;
               if (e && typeof e === 'object' && e instanceof Error) {
                 errMsg = e.stack;
@@ -134,9 +134,6 @@ module.exports = function(app) {
               }
 
               var output = 'Could not load Connect session adapter :: ' + adapter + '\n';
-              if (packagejson && !packagejson.main) {
-                output+='(If this is your module, make sure that the module has a "main" configuration in its package.json file)';
-              }
               output+='\nError from adapter:\n'+ errMsg+'\n\n';
 
 
@@ -160,24 +157,12 @@ module.exports = function(app) {
             };
 
             try {
-
-              // Determine the path to the adapter by using the "main" described in its package.json file:
-              var pathToAdapterDependency;
-              var pathToAdapterPackage = path.resolve(app.config.appPath, 'node_modules', sessionConfig.adapter ,'package.json');
-              var adapterPackage;
-              try {
-                adapterPackage = require(pathToAdapterPackage);
-                pathToAdapterDependency = path.resolve(app.config.appPath, 'node_modules', sessionConfig.adapter, adapterPackage.main);
-              }
-              catch (e) {
-                return cb(COULD_NOT_REQUIRE_CONNECT_ADAPTER_ERR(sessionConfig.adapter, adapterPackage, e));
-              }
-              var SessionAdapter = require(pathToAdapterDependency);
+              var SessionAdapter = require.main.require(sessionConfig.adapter);
               var CustomStore = SessionAdapter(require('express'));
               sessionConfig.store = new CustomStore(sessionConfig);
             } catch (e) {
               // TODO: negotiate error and give better error msg depending on code
-              return cb(COULD_NOT_REQUIRE_CONNECT_ADAPTER_ERR(sessionConfig.adapter, adapterPackage, e));
+              return cb(COULD_NOT_REQUIRE_CONNECT_ADAPTER_ERR(sessionConfig.adapter, e));
             }
           }
         }


### PR DESCRIPTION
npm can resolve the path to a module from the top level app automatically with `require.main.require`, without having to first attempt to read the package.json, then the main property, then resolve again.

This also helps to support modules like (the newly released v1) `connect-mongo`, which do not define a "main" property in their package.json, and rely on defaulting to ./index.js.