### PR TITLE
Added Access-Control-Max-Age to CORS hool with maxAge config option

### DIFF
--- a/lib/hooks/cors/index.js
+++ b/lib/hooks/cors/index.js
@@ -187,6 +187,9 @@ module.exports = function(sails) {
         if (req.method == "OPTIONS") {
           res.set('Access-Control-Allow-Methods', !_.isUndefined(routeCorsConfig.methods) ? routeCorsConfig.methods : sails.config.cors.methods);
           res.set('Access-Control-Allow-Headers', !_.isUndefined(routeCorsConfig.headers) ? routeCorsConfig.headers : sails.config.cors.headers);
+          if(!_.isUndefined(routeCorsConfig.maxAge) || !_.isUndefined(sails.config.cors.maxAge)) {
+          	res.set('Access-Control-Max-Age', !_.isUndefined(routeCorsConfig.maxAge) ? routeCorsConfig.maxAge : sails.config.cors.maxAge);
+          }
         }
 
       }
@@ -208,6 +211,7 @@ module.exports = function(sails) {
       res.set('Access-Control-Allow-Methods', '');
       res.set('Access-Control-Allow-Headers', '');
       res.set('Access-Control-Expose-Headers', '');
+      res.set('Access-Control-Max-Age', '');
     }
 
     next();


### PR DESCRIPTION
Just a quick one but can help a lot reducing the number of HTTP calls.

Not sure about defining maxAge as default since the header is optional.
Also not sure if changes are needed to sails-generate.
