### PR TITLE
Proposal to add Proxy Protocol support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,6 +52,7 @@ Feature                                          | Proposal                     
  :---------------------------------------------- | :------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------
  Generate `test/` folder in new Sails apps       | [#2499](https://github.com/balderdashy/sails/pull/2499#issuecomment-171556544)        | Generate a generic setup for mocha tests in all new Sails apps.  Originally suggested by [@jedd-ahyoung](https://github.com/jedd-ahyoung).
  `sails.getRouteAddress()`                       | [#3402](https://github.com/balderdashy/sails/issues/3402#issuecomment-167137610)   | Given a route target, return the route address configured in the app's explicit routes.
+ Allow Proxy Protocol-wrapped streams            | (not assigned) | Preserve the originator's IP address while using websockets behind a proxy.  Normal HTTP header injection will not work.  Also enables use behind an Amazon ELB.
 
 
 


### PR DESCRIPTION
In order to pass websocket traffic through Amazon's elastic load balancers (ELBs), you must force the ELB to proxy TCP traffic instead of HTTP traffic.  These proxies are application-level and do not forward network packets verbatim.  In order to know the source IP, Amazon allows [Proxy Protocol](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html) (as defined in HAProxy's [spec](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt)) to be enabled on the ELBs, so the source and destination IP + port can be preserved.

As mentioned in balderdashy/sails#3505, this requires a change to the http hook (code mentioned in the issue) and the use of [another module](https://github.com/findhit/proxywrap) to unwrap the TCP traffic and pull off the first line of the request, which contains the Proxy Protocol information.  Excerpts from that issue are included here.

I would suggest using a flag to the configuration object, such as `proxyProtocol = true` or `http.proxyProtocol = true`.  When truthy, Proxy Protocol would be enabled and required.  When falsy, Proxy Protocol support would be disabled.

Comments from the original issue:

> It looks like one could easily add support with code in lib/hooks/http/initialize.js, perhaps roughly at line 50. I don't know if this follows the same coding method as you, so I present it here for your review instead of in a pull request.
> 
>     if (sails.config.proxyProtocol == true) {
>         var httpConnectionElement = usingSSL ? require('https') : require('http');
>         var proxiedHttp = require('findhit-proxywrap').proxy(httpConnectionElement);
>         createServer = proxiedHttp.createServer;
>     }
>
> For this code to work, I was told that connectSailsClient() in lib/hooks/sockets/lib/initialize.js (about line 130) needed to be commented out, though I don't know the details and can not elaborate on why this is the case.