### PR TITLE
[Patch] Update regex to parse hook names from module identities

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -433,7 +433,7 @@ module.exports = function(sails) {
               }
               // Otherwise use the module name, with initial "sails-hook" stripped off if it exists
               else {
-                hookName = identity.match(/^sails-hook-/) ? identity.replace(/^sails-hook-/,'') : identity;
+                hookName = identity.match(/^(sails-hook-)|(@.+\/sails-hook-)/) ? identity.replace(/^(sails-hook-)|(@.+\/sails-hook-)/,'') : identity;
               }
 
               if (sails.config.hooks[hookName] === false) {


### PR DESCRIPTION
This allows the hook names to be correctly parsed from modules published to npm under a user's namespace/scope - e.g. `@user/sails-hook-name`

Follows discussion in #3502 