### PR TITLE
[Proposal] Don't bind services to module context

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ Change                                           | Proposal                     
  :---------------------------------------------- | :------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------
  Generate `test/` folder in new Sails apps       | [#2499](https://github.com/balderdashy/sails/pull/2499#issuecomment-171556544)        | Generate a generic setup for mocha tests in all new Sails apps.  Originally suggested by [@jedd-ahyoung](https://github.com/jedd-ahyoung).
  `sails.getRouteAddress()`                       | [#3402](https://github.com/balderdashy/sails/issues/3402#issuecomment-167137610)   | Given a route target, return the route address configured in the app's explicit routes.
-| Don't bind context in app's services           | []() | Don't bind context (`this`) in modules loaded from `api/services/`
+| Don't bind context in app's services           | [#3536](https://github.com/balderdashy/sails/pull/3536) | Don't bind context (`this`) in modules loaded from `api/services/`
 
 
 &nbsp;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,11 +48,11 @@ The backlog consists of approved proposals for useful features which are not cur
 > - Once your pull request has been created, add an additional commit which links to it from your new row in the table below.
 
 
-Feature                                          | Proposal                                                                              | Summary
+Change                                           | Proposal                                                                              | Summary
  :---------------------------------------------- | :------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------
  Generate `test/` folder in new Sails apps       | [#2499](https://github.com/balderdashy/sails/pull/2499#issuecomment-171556544)        | Generate a generic setup for mocha tests in all new Sails apps.  Originally suggested by [@jedd-ahyoung](https://github.com/jedd-ahyoung).
  `sails.getRouteAddress()`                       | [#3402](https://github.com/balderdashy/sails/issues/3402#issuecomment-167137610)   | Given a route target, return the route address configured in the app's explicit routes.
-
+| Don't bind context in app's services           | []() | Don't bind context (`this`) in modules loaded from `api/services/`
 
 
 &nbsp;


### PR DESCRIPTION
This behavior will stay as is for 0.12, but I'd like to tentatively plan to remove the automatic binding of context in services for Sails v1.0.  I don't have time right now to spec this further, however I don't think this one will be a whole lot of work to spec out.  The biggest thing is to put together a list of links to the places in the docs this will need to change (or get added).
# See [original issue](https://github.com/balderdashy/sails/issues/2665) from @natecavanaugh for more info.  Included pertinent info below for context:

Hi there,
This was working in 10.4, but in 11, as of 97861aa30da56eef2907516010ac31157e8c3abe there is a use case that is broken.
Let's say we have `EmailService.js`

```
var EmailService = function(){
// Do some stuff
};
EmailService.foo = 'Some Value';
module.exports = EmailService;
```

When the module loader is calling _.bindAll, it's replacing all methods on the object with a "bound" version, but it completely wipes out any existing properties on that function.

It could be all well and good to say "Don't export functions", but 1. it does it to every function on the object, not just the exported one (so if `EmailService.foo` were a function, and had properties, those would be wiped out as well), and 2. we may be exporting a third party library, where we don't control the kind of object that's being exported.

Since `_.bindAll` is destructive, I would suggest making this something the service can opt into or control themselves.
