### PR TITLE
Support passing configuration options to the default body parser

### DIFF
--- a/lib/hooks/http/middleware/defaults.js
+++ b/lib/hooks/http/middleware/defaults.js
@@ -109,7 +109,7 @@ module.exports = function(sails, app) {
         // middleware provided with options
         if (typeof conf === 'object') {
           opts = conf.options || opts;
-          fn = conf.fn;
+          fn = conf.fn || require('skipper');
           return fn(opts);
         }
         // middleware function defined directly


### PR DESCRIPTION
I'd like to be able to set config options for the default ('skipper') body parser without having to explicitly depend on it, and pass it as a body-parser function in my app.

e.g. in config/hooks.js

```javascript
module.exports.http = {
    ...
    middleware: {
        bodyParser: {
            options: {
              limit:'10mb'
            }
        }
    }
    ...
}

As it is, I am forced to pass `fn: require('skipper')` and add skipper to my dependencies, which is a bit longwinded to simply pass an option.

By defaulting the `fn` option to skipper if the bodyParser config is an object then Sails can support passing options only to the default body parser.