### PR TITLE
Before adding a userhook to be loaded, check that it was not marked as 'not' to load via config

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -479,6 +479,7 @@ module.exports = function(sails) {
                 memo[hookName] = hook;
               }
             }
+            return memo;
           }, {}));
 
           return bindToSails(cb)(null, hooks);

--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -475,9 +475,10 @@ module.exports = function(sails) {
               hook.configKey = (sails.config.installedHooks && sails.config.installedHooks[identity] && sails.config.installedHooks[identity].configKey) || hookName;
 
               // Add this to the list of hooks to load
-              memo[hookName] = hook;
+              if(sails.hooks[hookName] !== false) {
+                memo[hookName] = hook;
+              }
             }
-            return memo;
           }, {}));
 
           return bindToSails(cb)(null, hooks);


### PR DESCRIPTION
It fixes https://github.com/balderdashy/sails-hook-sockets/issues/16, where the sails-hook-sockets is disabled via config, but since it is a module, it is being loaded via the userhook method