### PR TITLE
fixed sails.sockets.id() is deprecated; use sails.sockets.getId() warning msg

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -1255,7 +1255,7 @@ module.exports = function(sails) {
         }
 
         sails.sockets.join(socket, this._classRoom());
-        sails.log.silly("Subscribed socket ", sails.sockets.id(socket), "to", this._classRoom());
+        sails.log.silly("Subscribed socket ", sails.sockets.getId(socket), "to", this._classRoom());
 
         // if (sails.config.sockets['backwardsCompatibilityFor0.9SocketClients'] && socket.handshake) {
         //   var sdk = app.getSDKMetadata(socket.handshake);
@@ -1281,7 +1281,7 @@ module.exports = function(sails) {
         }
 
         sails.sockets.leave(socket, this._classRoom());
-        sails.log.silly("Unubscribed socket ", sails.sockets.id(socket), "from", this._classRoom());
+        sails.log.silly("Unubscribed socket ", sails.sockets.getId(socket), "from", this._classRoom());
 
         // if (sails.config.sockets['backwardsCompatibilityFor0.9SocketClients'] && socket.handshake) {
         //   var sdk = app.getSDKMetadata(socket.handshake);


### PR DESCRIPTION
Sails 0.12.0 deprecated sails.sockets.id() method. 
One of the core hooks pubsub still uses this method and triggers a warning
```
sails.sockets.id() is deprecated; use sails.sockets.getId().
```
This patch fixes the issue.