### PR TITLE
Added ability to specify which columns to select in the find blueprint

### DIFF
--- a/lib/hooks/blueprints/actionUtil.js
+++ b/lib/hooks/blueprints/actionUtil.js
@@ -206,7 +206,7 @@ var actionUtil = {
 
     // Allow customizable blacklist for params NOT to include as criteria.
     req.options.criteria = req.options.criteria || {};
-    req.options.criteria.blacklist = req.options.criteria.blacklist || ['limit', 'skip', 'sort', 'populate'];
+    req.options.criteria.blacklist = req.options.criteria.blacklist || ['limit', 'skip', 'sort', 'populate', 'columns'];
 
     // Validate blacklist to provide a more helpful error msg.
     var blacklist = req.options.criteria && req.options.criteria.blacklist;

--- a/lib/hooks/blueprints/actions/find.js
+++ b/lib/hooks/blueprints/actions/find.js
@@ -15,6 +15,7 @@ var actionUtil = require('../actionUtil'),
  * with that unique id will be returned.
  *
  * Optional:
+ * @param {String} columns     - the columns that you want returned. Should be comma separated. (i.e. /Model?columns=column1,column2)
  * @param {Object} where       - the find criteria (passed directly to the ORM)
  * @param {Integer} limit      - the maximum number of records to send back (useful for pagination)
  * @param {Integer} skip       - the number of records to skip (useful for pagination)
@@ -28,16 +29,21 @@ module.exports = function findRecords (req, res) {
   var Model = actionUtil.parseModel(req);
 
 
+  // ** Comment this out because it fails with the columns parameter
   // If an `id` param was specified, use the findOne blueprint action
   // to grab the particular instance with its primary key === the value
   // of the `id` param.   (mainly here for compatibility for 0.9, where
   // there was no separate `findOne` action)
-  if ( actionUtil.parsePk(req) ) {
-    return require('./findOne')(req,res);
-  }
+  //if ( actionUtil.parsePk(req) ) {
+  //  return require('./findOne')(req,res);
+  //}
+  
+  // Parse the columns that were specified by the user in the "columns" parameter of the URL.
+  // If no columns were specified, use all columns.
+  var columns = req.param('columns') ? {select: req.param('columns').replace(/ /g, '').split(',')} : {};
 
   // Lookup for records that match the specified criteria
-  var query = Model.find()
+  var query = Model.find(columns)
   .where( actionUtil.parseCriteria(req) )
   .limit( actionUtil.parseLimit(req) )
   .skip( actionUtil.parseSkip(req) )


### PR DESCRIPTION
Added ability to specify which columns to select in the find blueprint. With this, columns can now be specified in the URL when calling /:Model by simply adding the "columns" parameter. The columns should be separated by a comma. I.e. /:Model?columns=column1,column2