### PR TITLE
Ensure req._sails is always set

### DIFF
--- a/lib/hooks/http/initialize.js
+++ b/lib/hooks/http/initialize.js
@@ -99,6 +99,11 @@ module.exports = function(sails) {
             });
         }
 
+        app.use(function (req, res, next) {
+            req._sails = sails;
+            next();
+        });
+
         // When Sails binds routes, bind them to the internal Express router
         sails.on('router:bind', function(route) {
 

--- a/test/integration/middleware.sails.test.js
+++ b/test/integration/middleware.sails.test.js
@@ -1,0 +1,59 @@
+var request = require('request');
+var Sails = require('../../lib').Sails;
+var assert = require('assert');
+
+describe('middleware :: ', function() {
+
+  describe('sails :: ', function() {
+
+    describe('http requests :: ', function() {
+
+      var sid;
+
+      // Lift a Sails instance in production mode
+      var app = Sails();
+      before(function (done){
+        app.lift({
+          globals: false,
+          port: 1535,
+          environment: 'development',
+          log: {level: 'silent'},
+          session: {
+            secret: 'abc123'
+          },
+          hooks: {
+            grunt: false,
+            request: false
+          },
+          routes: {
+            '/test': function(req, res) {
+              var defined = (req._sails !== undefined) ? 'defined' : 'undefined';
+              res.send("req._sails is " + defined);
+            }
+          }
+        }, done);
+      });
+
+      after(function(done) {
+        return app.lower(function(){setTimeout(done, 100);});
+      });
+
+      it('req._sails should be set if request hook is disabled', function(done) {
+
+        request(
+          {
+            method: 'GET',
+            uri: 'http://localhost:1535/test',
+          },
+          function(err, response, body) {
+            assert.equal(body, 'req._sails is defined');
+            return done();
+          }
+        );
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Certain parts of the codebase - in particular the built is response functions (e.g. `res.serverError` etc) access `req._sails` to gain access to log functions. However, the setting of `req._sails` is currently bundled with the "request" hook, which contains potentially undesirable code - in particular around parsing `req.params.all()`, which can have a severe performance impact in certain situations - so may be disabled.

By setting `req._sails` by default on all requests we can ensure that the built in response helpers are usable indepenently of what intermediate hooks and middleware have loaded.

Fixes #3598 