### PR TITLE
[fixes #3592] allow sails.config.http.middleware.bodyParser config to work

### DIFF
--- a/lib/hooks/http/middleware/defaults.js
+++ b/lib/hooks/http/middleware/defaults.js
@@ -111,58 +111,6 @@ module.exports = function(sails, app) {
         return undefined;
       }
 
-      // Handle new middleware config:
-      ////////////////////////////////////////////////////////
-      var conf = sails.config.http.middleware.bodyParser;
-      if (conf) {
-        // middleware provided with options
-        if (typeof conf === 'object') {
-          opts = conf.options || opts;
-          fn = conf.fn;
-          return fn(opts);
-        }
-        // middleware function defined directly
-        else if (typeof conf === 'function') {
-          fn = conf;
-          var configuredFn;
-
-          try {
-            configuredFn = fn(opts);
-          }
-          catch (e) {
-            sails.on('lifted', function () {
-              sails.log.error(e);
-              sails.log.blank();
-              sails.log.error('Encountered an error when trying to use configured bodyParser.');
-              sails.log.error('Usually, this means that it was installed incorrectly.');
-              sails.log.error('A custom bodyParser can be configured without calling the wrapper function- e.g.:\n'+
-                '```\n'+
-                'bodyParser: require("connect-busboy")\n'+
-                '```'
-              );
-              sails.log.error(
-              'Alternatively, if you need to provide options:\n'+
-              '```\n'+
-              'bodyParser: {\n'+
-              '  fn: require("connect-busboy"),\n'+
-              '  options: {/* ... */}\n'+
-              '}\n'+
-              '```');
-            });
-          }
-          return configuredFn;
-        }
-        // invalid conf - warn and ignore
-        else {
-          // TODO: pull this out into a more generic config validator for Sails in general
-          sails.log.warn(
-            'Invalid `http.middleware.bodyParser` config: `' + conf + '`',
-            'Proper usage:\n' +
-            '{ options: {}, fn: function () {} }'
-          );
-        }
-      }
-
       // Default to built-in bodyParser:
       fn = require('skipper');
       return fn(opts);

--- a/test/hooks/http/initialize.test.js
+++ b/test/hooks/http/initialize.test.js
@@ -1,0 +1,51 @@
+/**
+ * Module dependencies
+ */
+
+var assert = require('assert');
+var util = require('util');
+var Sails = require('../../../lib').Sails;
+var $Router = require('../../helpers/router');
+var request = require('request');
+
+describe('HTTP hook', function (){
+
+  describe('with custom bodyparser middleware config', function() {
+
+    var app;
+    before(function(done) {
+      app = Sails();
+      app.lift({
+        globals: false,
+        loadHooks: [
+          'moduleloader',
+          'userconfig',
+          'http'
+        ],
+        log: {level: 'silent'},
+        http: {
+          middleware: {
+            bodyParser: function(req, res, next) {
+              req.foo = 'bar';
+              return next();
+            }
+          }
+        },
+        routes: {
+          'get /': function(req, res) {return res.send(req.foo);}
+        },
+        port: 1342
+      }, done);
+    });
+    after(function(done) {
+      app.lower(done);
+    });
+    it('should be able to respond to requests using the custom bodyparser', function(done) {
+      request.get('http://localhost:1342', function(err, res, body) {
+        assert.equal(body, 'bar');
+        return done();
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
This basically removes most of the code from the `bodyParser` property of the object in `hooks/http/middleware/defaults.js`.  I think this code was written when Skipper was just getting started and needed a bit more handholding, but it probably hasn't worked for a long time.  It's _supposed_ to take the value of `sails.config.http.middleware.bodyParser`, validate it, and use it to get a body parser middleware function to use in the app.  But because all of the code in `defaults.js` is wrapped in a big `_.defaults(sails.config.http.middleware, {...}`, the function that gets returned is never used, since there's already something in `sails.config.http.middleware.bodyParser`.  The catch 22 is, an Express middleware function will _not_ pass the validation in `defaults.js`, so an error will be thrown and Sails won't lift--but if you put in the kind of value that _will_ pass validation, then that value (and not an Express middleware function) will get used as the body parser, and all requests will hang.

A corollary to this PR would be to change the example in `config/http.js` from:
```
bodyParser: require('skipper')
```
to
```
bodyParser: require('skipper')({maxTimeToBuffer: 24400})
```
(or some other options; just anything that demonstrates proper usage)

You _can_ currently specify a custom config by using `sails.config.http.bodyParser`, so we should keep and deprecate that (undocumented) usage.  But at this point our http hook is solid enough that it's safe to have `middleware.bodyParser` be the same as all the other middleware config:  you just give it a function with `req`, `res` and `next`.