### PR TITLE
Ensure req._sails is present when responses hook is used

### DIFF
--- a/lib/hooks/responses/index.js
+++ b/lib/hooks/responses/index.js
@@ -133,6 +133,10 @@ module.exports = function(sails) {
          */
         'all /*': function addResponseMethods(req, res, next) {
 
+          // req._sails is used in error responses to provide access to sails.log
+          // ensure it exists on the request object
+          req._sails = req._sails || sails;
+
           // Attach res.jsonx to `res` object
           _mixin_jsonx(req,res);
 


### PR DESCRIPTION
The default responses use req._sails to provide access to the logger in order to write error cases to logs. Ensure that the req._sails property is present on the request object without creating a dependency on the request hook to be installed.