### PR TITLE
[Fixes #3604] Fix nested views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Master
 
+* [BUGFIX] Allow view target syntax for routes to specify deeply-nested views [3604](https://github.com/balderdashy/sails/issues/3604)
 * [BUGFIX] Allow custom bodyParser middleware config [3592](https://github.com/balderdashy/sails/issues/3592)
 
 ### 0.12.1

--- a/lib/hooks/views/actions.js
+++ b/lib/hooks/views/actions.js
@@ -9,68 +9,11 @@ var _ = require('lodash');
  */
 module.exports = function detectAndPrepareViews (sails, hook) {
   sails.modules.statViews(function (err, detectedViews) {
-    if (err) throw err;
+    if (err) {throw err;}
 
     // Save existence tree in `sails.views` for consumption later
     sails.views = detectedViews || {};
 
-    // Generate view-serving middleware and stow it in `hook.middleware`
-    createMiddleware(detectedViews);
   });
 
-  /**
-   * Generates view-serving middleware for each view
-   */
-  function createMiddleware (detectedViews) {
-    // If there are any matching views which don't have an action
-    // create middleware to serve them
-    _.each(detectedViews, function (view, id) {
-
-      // Create middleware for a top-level view
-      if (view === true) {
-        sails.log.silly('Building action for view: ', id);
-        hook.middleware[id] = serveView(id);
-      }
-
-      // Create middleware for each subview
-      else {
-        hook.middleware[id] = {};
-        for (var subViewId in detectedViews[id]) {
-          sails.log.silly('Building action for view: ', id, '/', subViewId);
-          hook.middleware[id][subViewId] = serveView(id, subViewId);
-        }
-      }
-    });
-  }
-
-  /**
-   * Returns a middleware chain that remembers a view id and
-   * runs simple middleware to template and serve the view file.
-   * Used to serve views w/o controllers
-   *
-   * (This concatenation approach is crucial to allow policies to be bound)
-   *
-   * @param  {[type]} viewId    [description]
-   * @param  {[type]} subViewId [description]
-   * @return {Array}
-   */
-  function serveView (viewId, subViewId) {
-    // Save for use in closure
-    // (handle top-level and subview cases)
-    var viewExpression = viewId + (subViewId ? '/' + subViewId : '');
-
-    return [
-      function rememberViewId(req, res, next) {
-        // Save reference for view in res.view() middleware
-        // (only needs to happen if subViewId is not set [top-level view])
-        if (viewId) {
-          req.options.view = viewExpression;
-        }
-        next();
-      },
-      function serveView(req, res) {
-        res.view();
-      }
-    ];
-  }
 };

--- a/lib/hooks/views/onRoute.js
+++ b/lib/hooks/views/onRoute.js
@@ -52,56 +52,31 @@ module.exports = function onRoute (sails, route) {
    */
   function bindView ( path, target, verb, options ) { //:TODO 'options' is defined but never used.
 
-    // Get view names
-    var view = target.view.split('/')[0];
-    var subview = target.view.split('/')[1] || 'index';
+    // Transform the view path into something Lodash _.get will understand (i.e. dots not slashes)
+    var viewPath = target.view.replace(/\//g, '.');
 
-    // Look up appropriate view and make sure it exists
-    var viewMiddleware = sails.middleware.views[view];
-    // Dereference subview if the top-level view middleware is actually an object
-    if (_.isPlainObject(viewMiddleware)) {
-      viewMiddleware = viewMiddleware[subview];
-    }
-
-    // If a view was specified but it doesn't match,
-    // ignore the attempt and inform the user
-    if ( !viewMiddleware ) {
-      sails.log.error(
-        'Ignoring attempt to bind route (' +
-        path + ') to unknown view: ' + target.view
-      );
-      return;
-    }
-
-    // Make sure the view function (+/- policies, etc.) is usable
-    // If it's an array, bind each action to the destination route in order
-    else if (_.isArray(viewMiddleware)) {
-      _.each(viewMiddleware, function (fn) {
-        sails.router.bind(path, viewHandler(fn), verb, _.extend(target, {log: 'VIEW'}));
+    // Look up the view in our views hash
+    if (_.get(sails.views, viewPath) === true) {
+      return sails.router.bind(path, function serveView(req, res) {
+        res.view(target.view);
       });
-      return;
     }
 
-    // Bind an action which renders this view to the destination route
-    else {
-      sails.router.bind(path, viewHandler(viewMiddleware), verb, _.extend(target, {log: 'VIEW'}));
-      return;
-    }
-
-
-    // Wrap up the view middleware to supply access to
-    // the original target when requests comes in
-    function viewHandler (originalFn) {
-
-      if ( !_.isFunction(originalFn) ) {
-        sails.log.error(
-          'Error binding view to route :: View middleware is not a function!',
-          originalFn, 'for path: ', path, verb ? ('and verb: ' + verb) : '');
-        return;
+    // For backwards compatibility, look for an index view if the specified view was
+    // top-level and could not be found
+    if (viewPath.indexOf('.') === -1) {
+      if (_.get(sails.views, viewPath + '.index') === true) {
+        return sails.router.bind(path, function serveView(req, res) {
+          res.view(viewPath + '/index');
+        });
       }
-
-      // Bind intercepted middleware function to route
-      return originalFn;
     }
+
+    sails.log.error(
+      'Ignoring attempt to bind route (' +
+      path + ') to unknown view: ' + target.view
+    );
+    return;
+
   }
 };

--- a/lib/hooks/views/res.view.js
+++ b/lib/hooks/views/res.view.js
@@ -44,7 +44,7 @@ module.exports = function _addResViewMethod(req, res, next) {
       }
 
       // But if some other sort of error occurred, call `res.serverError`
-      else if (err) return res.serverError(err);
+      else if (err) {return res.serverError(err);}
 
       // Otherwise we're good, serve the view
       return res.send(html);
@@ -87,7 +87,7 @@ module.exports = function _addResViewMethod(req, res, next) {
       relPathToView = (req.options.controller||req.options.model) + '/' + (req.options.action || 'index');
     }
     // Use the new view config
-    else relPathToView = req.options.view;
+    else {relPathToView = req.options.view;}
 
     // Now we have a reasonable guess in `relPathToView`
 
@@ -133,7 +133,7 @@ module.exports = function _addResViewMethod(req, res, next) {
       req._errorInResView = err;
 
       if (cb_view) { return cb_view(err); }
-      else return res.serverError(err);
+      else {return res.serverError(err);}
     }
 
 
@@ -308,7 +308,7 @@ module.exports = function _addResViewMethod(req, res, next) {
           else if (process.env.NODE_ENV !== 'production') {
             return res.json(500, err);
           }
-          else return res.send(500);
+          else {return res.send(500);}
           //
           //////////////////////////////////////////////////////////////////
         }

--- a/test/integration/fixtures/sampleapp/views/app/index.ejs
+++ b/test/integration/fixtures/sampleapp/views/app/index.ejs
@@ -1,0 +1,1 @@
+App index file

--- a/test/integration/fixtures/sampleapp/views/app/user/homepage.ejs
+++ b/test/integration/fixtures/sampleapp/views/app/user/homepage.ejs
@@ -1,0 +1,1 @@
+I'm deeply nested!

--- a/test/integration/router.viewRendering.test.js
+++ b/test/integration/router.viewRendering.test.js
@@ -3,81 +3,81 @@ var httpHelper = require('./helpers/httpHelper.js');
 var appHelper = require('./helpers/appHelper');
 
 describe('router :: ', function() {
-	describe('View routes', function() {
-		var appName = 'testApp';
+  describe('View routes', function() {
+    var appName = 'testApp';
 
-		before(function(done) {
-			appHelper.build(done);
-		});
+    before(function(done) {
+      appHelper.build(done);
+    });
 
-		beforeEach(function(done) {
-			appHelper.lift({verbose: false}, function(err, sails) {
-				if (err) {throw new Error(err);}
-				sailsprocess = sails;
-				setTimeout(done, 100);
-			});
-		});
+    beforeEach(function(done) {
+      appHelper.lift({verbose: false}, function(err, sails) {
+        if (err) {throw new Error(err);}
+        sailsprocess = sails;
+        setTimeout(done, 100);
+      });
+    });
 
-		afterEach(function(done) {
-			sailsprocess.kill(function(){setTimeout(done, 100);});
-		});
+    afterEach(function(done) {
+      sailsprocess.kill(function(){setTimeout(done, 100);});
+    });
 
-		after(function() {
-			process.chdir('../');
-			appHelper.teardown();
-		});
+    after(function() {
+      process.chdir('../');
+      appHelper.teardown();
+    });
 
-		describe('with default routing', function() {
+    describe('with default routing', function() {
 
-			it('should respond to a get request to localhost:1342 with welcome page', function(done) {
+      it('should respond to a get request to localhost:1342 with welcome page', function(done) {
 
-				httpHelper.testRoute('get', '', function(err, response) {
-					if (err) {return done(new Error(err));}
+        httpHelper.testRoute('get', '', function(err, response) {
+          if (err) {return done(new Error(err));}
 
-					assert(response.body.indexOf('not found') < 0);
-					assert(response.body.indexOf('<!-- Default home page -->') > -1);
-					done();
-				});
-			});
+          assert(response.body.indexOf('not found') < 0);
+          assert(response.body.indexOf('<!-- Default home page -->') > -1);
+          done();
+        });
+      });
 
-			it('should wrap the view in the default layout', function(done) {
+      it('should wrap the view in the default layout', function(done) {
 
-				httpHelper.testRoute('get', '', function(err, response) {
-					if (err) {return done(new Error(err));}
-					assert(response.body.indexOf('<html>') > -1);
-					done();
-				});
-			});
+        httpHelper.testRoute('get', '', function(err, response) {
+          if (err) {return done(new Error(err));}
+          assert(response.body.indexOf('<html>') > -1);
+          done();
+        });
+      });
 
-		});
+    });
 
-		describe('with no specified routing', function() {
+    describe('with no specified routing', function() {
 
-			before(function() {
-				httpHelper.writeRoutes({});
-			});
+      before(function() {
+        httpHelper.writeRoutes({});
+      });
 
-			it('should respond to get request to :controller with the template at views/:controller/index.ejs', function(done) {
+      it('should respond to get request to :controller with the template at views/:controller/index.ejs', function(done) {
 
-				// Empty router file
+        // Empty router file
 
-				httpHelper.testRoute('get', 'viewTest', function(err, response) {
-					if (err) {return done(new Error(err));}
+        httpHelper.testRoute('get', 'viewTest', function(err, response) {
+          if (err) {return done(new Error(err));}
 
-					assert(response.body.indexOf('indexView') !== -1, response.body);
-					done();
-				});
-			});
+          assert(response.body.indexOf('indexView') !== -1, response.body);
+          done();
+        });
+      });
 
-			it('should respond to get request to :controller/:action with the template at views/:controller/:action.ejs', function(done) {
+      it('should respond to get request to :controller/:action with the template at views/:controller/:action.ejs', function(done) {
 
-				httpHelper.testRoute('get', 'viewTest/create', function(err, response) {
-					if (err) {return done(new Error(err));}
+        httpHelper.testRoute('get', 'viewTest/create', function(err, response) {
+          if (err) {return done(new Error(err));}
 
-					assert(response.body.indexOf('createView') !== -1);
-					done();
-				});
-			});
+          assert(response.body.indexOf('createView') !== -1);
+          done();
+        });
+      });
 
       it('should merge config.views.locals into the view locals', function(done) {
 
@@ -99,6 +99,6 @@ describe('router :: ', function() {
       });
 
 
-		});
-	});
+    });
+  });
 });


### PR DESCRIPTION
Now that `req.view` determines what to render based on what's in `req.options`, I don't see the utility of having a middleware function bound for each individual view, hence the removal of most of the code in `lib/hooks/views/action.js`.  If I'm missing something, lemme know.  Tests all pass without it though.  

Also added new tests for using the view target syntax (e.g. `'/foo': {view: 'foo/bar/baz'}`) and a test for the ability to do `'/foo': {view: 'foo'}` and have it render `views/foo/index.js` if it exists--not sure if that was ever documented, but the code was is in there so I made sure it still works.