### PR TITLE
[proposal] Call `res.serverError` if a controller function returns a rejected Promise

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,6 +32,7 @@ The backlog consists of approved proposals for useful features which are not cur
 Feature                                          | Proposal                                                                              | Summary
  :---------------------------------------------- | :------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------
  Generate `test/` folder in new Sails apps       | [#2499](https://github.com/balderdashy/sails/pull/2499#issuecomment-171556544)        | Generate a generic setup for mocha tests in all new Sails apps.  Originally suggested by [@jedd-ahyoung](https://github.com/jedd-ahyoung).
+ Call `res.serverError` if a controller returns a rejected Promise       | [#3642](https://github.com/balderdashy/sails/pull/3642)        | If a controller function returns a rejected Promise without sending a response, automatically call `res.serverError` with the rejection reason.
 
 
 


### PR DESCRIPTION
<!-- 
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact
sgress454@treeline.io

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!  
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example: 
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->

At the moment, if a controller function throws a synchronous error, `res.serverError` is called automatically. This is useful because it ensures that a response always gets sent back to the client, and it removes the need for boilerplate try-catch statements.

However, this functionality does not currently exist for asynchronous controller functions. As a result, it's possible for an async function to silently throw an error, without ever sending a response.

Here's an example of a controller file to demonstrate why this can be an issue:

```js
// SomeController.js

exports.function1 = function (req, res) {
  // This automatically calls res.serverError under the hood
  throw 'something bad happened.';
};

exports.function2 = async function (req, res) {
  /* At the moment, this does not automatically call res.serverError.
  Instead, the error gets swallowed and no response is sent.
  A workaround is to wrap the entire function in a try-catch, but that leads to a lot of boilerplate code.
  (This example uses ES7 async functions, but the issue applies to any code that runs asynchronously.) */
  throw 'something bad happened asynchronously.';
};
```
To resolve this inconsistency, I propose that **controller functions should be able to return a Promise. If that Promise ends up rejecting, `res.serverError` is automatically called with the rejection reason, as if an error was thrown synchronously.** If this proposal were implemented, `function1` and `function2` above would both result in a call to `res.serverError`.

Mocha allows a similar type of thing, e.g.

```js
it('does some asynchronous test', function () {
  // The test suite succeeds if somePromise fulfills, and fails if somePromise rejects
  return somePromise;
});
```

I think this behavior would get rid of boilerplate controller code and help prevent silent errors, with no significant downsides.
