### PR TITLE
[proposal] Force async-ness in template rendering methods

### DIFF
--- a/lib/hooks/views/configure.js
+++ b/lib/hooks/views/configure.js
@@ -73,7 +73,10 @@ module.exports = function configure ( sails ) {
     }
 
     // Save reference to view rendering function
-    sails.config.views.engine.fn = fn;
+    // munge callback to protect against https://github.com/tj/consolidate.js/issues/143
+    sails.config.views.engine.fn = function (str, options, cb) {
+      fn(str, options, function (e, result) { setImmediate(function () { cb(e, result); }); });
+    }
     sails.log.silly('Configured view engine, `' + engineName + '`');
   }
 


### PR DESCRIPTION
<!-- 
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact
sgress454@treeline.io

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!  
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example: 
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->


There is a long-standing open bug in consolidate - https://github.com/tj/consolidate.js/issues/143 - which causes errors in the callback functions passed to rendering methods to propogate back into the try/catch contained in consolidate and cause the callback to be fired twice. Since this bug has been open in consolidate for over two years, not much hope should be held of having it resolved there.

As such, add protection in Sails against errors in the callback functions being caught inside consolidate and the callback fired twice by forcing the callback to be called asynchronously.

Example:

```javascript
res.view('template', {}, function (e, result) {
  if (e) {
    // error thrown below causes callback to be fired twice and error caught here
  }
  throw new Error('error');
});
```

This can cause errors in userland code to be incorrectly attributed to template rendering and makes debugging difficult.

I appreciate that this *should* be fixed at the root in consolidate, but after 2 years, and with the [maintainer insisting it is not a bug](https://github.com/tj/consolidate.js/issues/143#issuecomment-37481417), I don't hold much hope for that.