### PR TITLE
[patch] Sails.prototype.inspect() - fix link to docs

### DIFF
--- a/lib/app/private/inspect.js
+++ b/lib/app/private/inspect.js
@@ -21,7 +21,7 @@ module.exports = function inspect () {
 
   return util.format('\n'+
   '  |>   %s', this.toString()) + '\n' +
-  '\\___/  For help, see: http://links.sailsjs.org/docs'+
+  '\\___/  For help, see: http://sailsjs.org/documentation/concepts/'+
   '\n\n' +
   'Tip: Use `sails.config` to access your app\'s runtime configuration.'+
   '\n\n' +


### PR DESCRIPTION
Sails.prototype.inspect() which is triggered by running something like `console.log(sails);` links to old docs page (http://links.sailsjs.org/docs) from 2 years ago which is now non-existant. This patch changes link to http://sailsjs.org/documentation/concepts/

