### PR TITLE
[patch] Fix err variable using parent scope because of mispelled parameter

### DIFF
--- a/lib/app/private/initialize.js
+++ b/lib/app/private/initialize.js
@@ -84,7 +84,7 @@ module.exports = function initialize(cb) {
         return next();
       }
       return sails.hooks[hookName].handleLift(next);
-    }, function (er){
+    }, function (err){
       if (err) { return cb(err); }
       return cb(null, sails);
     });


### PR DESCRIPTION
<!-- 
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact
sgress454@treeline.io

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!  
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example: 
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->

Hello!
A coworker was getting some weird errors when he tried to lift a second app on a port that was already in use. It was odd to me that this error didn't propagate to the `err` parameter in the sails lift callback. After checking out the source, it appears that there was a typo in the final handler of `sails.runBootstrap`. Instead of receiving the `err` value from the async call on line 82, the `err` variable is instead referencing the one defined by `runBootstrap` on line 68.
I hope this helps!
