### PR TITLE
[patch] Use res.forbidden() instead of res.send(403)

### DIFF
--- a/lib/hooks/policies/index.js
+++ b/lib/hooks/policies/index.js
@@ -146,7 +146,7 @@ module.exports = function(sails) {
       // A false or null policy means NEVER allow any requests
       if (policy === false || policy === null) {
         var neverAllow = function neverAllow (req, res, next) {
-          res.send(403);
+          res.forbidden();
         };
         neverAllow._middlewareType = 'POLICY: neverAllow';
         return [neverAllow];


### PR DESCRIPTION
Default behaviour of `policy === false || policy === null` is to res.send(403).
This bypasses responses/forbidden.js and it's associated view.

