### PR TITLE
[proposal] remove wrench from test runner requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,8 +112,7 @@
     "root-require": "0.3.1",
     "should": "5.2.0",
     "socket.io-client": "1.4.6",
-    "supertest": "1.1.0",
-    "wrench": "1.5.8"
+    "supertest": "1.1.0"
   },
   "repository": {
     "type": "git",

--- a/test/integration/generate.test.js
+++ b/test/integration/generate.test.js
@@ -1,8 +1,7 @@
 describe('API and adapter generators', function() {
 
   var assert = require('assert');
-  var fs = require('fs');
-  var wrench = require('wrench');
+  var fs = require('fs-extra');
   var exec = require('child_process').exec;
   var path = require('path');
 
@@ -20,7 +19,7 @@ describe('API and adapter generators', function() {
   before(function(done) {
 
     if (fs.existsSync(appName)) {
-      wrench.rmdirSyncRecursive(appName);
+      fs.removeSync(appName);
     }
 
     exec('node ' + sailsBin + ' new ' + appName, function(err) {
@@ -39,7 +38,7 @@ describe('API and adapter generators', function() {
     process.chdir('../');
 
     if (fs.existsSync(appName)) {
-      wrench.rmdirSyncRecursive(appName);
+      fs.removeSync(appName);
     }
 
     done();

--- a/test/integration/helpers/appHelper.js
+++ b/test/integration/helpers/appHelper.js
@@ -6,7 +6,6 @@ var path = require('path');
 var child_process = require('child_process');
 var exec = child_process.exec;
 var fs = require('fs-extra');
-var wrench = require('wrench');
 var _ = require('lodash');
 var SocketIOClient = require('socket.io-client');
 var SailsIOClient = require('./sails.io.js');
@@ -70,9 +69,8 @@ module.exports = {
 
     // Cleanup old test fixtures
     if (fs.existsSync(appName)) {
-      wrench.rmdirSyncRecursive(path.resolve('./', appName));
+      fs.removeSync(path.resolve('./', appName));
     }
-    // TODO: replace this (^) with fsx.remove or mp-fs/rmrf
 
     // Create an empty directory for the test app.
     var appDirPath = path.resolve('./', appName);
@@ -86,33 +84,7 @@ module.exports = {
       }
 
       // Copy test fixtures to the test app.
-      ////////////////////////////////////////////////////////////////////////////////////
-      // TODO: replace all of this w/ one line via `fsx.copy()`.
-      var fixtures = wrench.readdirSyncRecursive('../test/integration/fixtures/sampleapp');
-      if (fixtures.length === 0) {
-        return done(new Error('Fixtures are missing.'));
-      }
-      fixtures.forEach(function _eachFixtureFile(file) {
-        var filePath = path.resolve('../test/integration/fixtures/sampleapp', file);
-
-        // Check if file is a directory
-        var stat = fs.statSync(filePath);
-
-        // Ignore directories
-        if (stat.isDirectory()) {
-          return;
-        }
-
-        // Copy file to test app.
-        var data = fs.readFileSync(filePath);
-
-        // Create file and any missing parent directories in its path
-        fs.createFileSync(path.resolve(file), data);
-        fs.writeFileSync(path.resolve(file), data);
-      });
-      ////////////////////////////////////////////////////////////////////////////////////
-
-      return done();
+      fs.copy('../test/integration/fixtures/sampleapp', './', done);
     });
   },
 
@@ -128,7 +100,7 @@ module.exports = {
 
     var dir = path.resolve('./', appName);
     if (fs.existsSync(dir)) {
-      wrench.rmdirSyncRecursive(dir);
+      fs.removeSync(dir);
     }
   },
 

--- a/test/integration/hook.3rdparty.test.js
+++ b/test/integration/hook.3rdparty.test.js
@@ -5,7 +5,6 @@ var assert = require('assert');
 var httpHelper = require('./helpers/httpHelper.js');
 var appHelper = require('./helpers/appHelper');
 var util = require('util');
-var wrench = require('wrench');
 var path = require('path');
 var fs = require('fs-extra');
 
@@ -25,7 +24,7 @@ describe('hooks :: ', function() {
       before(function(done) {
         fs.mkdirs(path.resolve(__dirname, "../..", appName, "node_modules"), function(err) {
           if (err) {return done(err);}
-          wrench.copyDirSyncRecursive(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/sails-hook-shout'));
+          fs.copySync(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/sails-hook-shout'));
           process.chdir(path.resolve(__dirname, "../..", appName));
           done();
         });
@@ -241,7 +240,7 @@ describe('hooks :: ', function() {
       before(function(done) {
         fs.mkdirs(path.resolve(__dirname, "../..", appName, "node_modules"), function(err) {
           if (err) {return done(err);}
-          wrench.copyDirSyncRecursive(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/shouty'));
+          fs.copySync(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/shouty'));
           process.chdir(path.resolve(__dirname, "../..", appName));
           done();
         });
@@ -323,7 +322,7 @@ describe('hooks :: ', function() {
       before(function(done) {
         fs.mkdirs(path.resolve(__dirname, "../..", appName, "node_modules"), function(err) {
           if (err) {return done(err);}
-          wrench.copyDirSyncRecursive(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/sails-hook-csrf'));
+          fs.copySync(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/sails-hook-csrf'));
           process.chdir(path.resolve(__dirname, "../..", appName));
           appHelper.liftQuiet(function(err, _sails) {
             if (err) {return done(err);}
@@ -354,7 +353,7 @@ describe('hooks :: ', function() {
       before(function(done) {
         fs.mkdirs(path.resolve(__dirname, "../..", appName, "node_modules"), function(err) {
           if (err) {return done(err);}
-          wrench.copyDirSyncRecursive(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/csrf'));
+          fs.copySync(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/csrf'));
           process.chdir(path.resolve(__dirname, "../..", appName));
           appHelper.liftQuiet(function(err, _sails) {
             if (err) {return done(err);}
@@ -386,7 +385,7 @@ describe('hooks :: ', function() {
         before(function(done) {
           fs.mkdirs(path.resolve(__dirname, "../..", appName, "node_modules", "@my-modules"), function(err) {
             if (err) {return done(err);}
-            wrench.copyDirSyncRecursive(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/@my-modules/shouty'));
+            fs.copySync(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/@my-modules/shouty'));
             process.chdir(path.resolve(__dirname, "../..", appName));
             appHelper.liftQuiet(function(err, _sails) {
               if (err) {return done(err);}
@@ -416,7 +415,7 @@ describe('hooks :: ', function() {
         before(function(done) {
           fs.mkdirs(path.resolve(__dirname, "../..", appName, "node_modules", "@my-modules"), function(err) {
             if (err) {return done(err);}
-            wrench.copyDirSyncRecursive(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/@my-modules/shouty'));
+            fs.copySync(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/@my-modules/shouty'));
             var packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname,'../../testApp/node_modules/@my-modules/shouty','package.json')));
             packageJson.sails.hookName = 'csrf';
             fs.writeFileSync(path.resolve(__dirname,'../../testApp/node_modules/@my-modules/shouty','package.json'), JSON.stringify(packageJson));
@@ -451,7 +450,7 @@ describe('hooks :: ', function() {
       before(function(done) {
         fs.mkdirs(path.resolve(__dirname, "../..", appName, "node_modules", "@my-modules"), function(err) {
           if (err) {return done(err);}
-          wrench.copyDirSyncRecursive(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/@my-modules/sails-hook-csrf'));
+          fs.copySync(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/@my-modules/sails-hook-csrf'));
           process.chdir(path.resolve(__dirname, "../..", appName));
           appHelper.liftQuiet(function(err, _sails) {
             if (err) {return done(err);}
@@ -481,7 +480,7 @@ describe('hooks :: ', function() {
       before(function(done) {
         fs.mkdirs(path.resolve(__dirname, "../..", appName, "node_modules", "@my-modules"), function(err) {
           if (err) {return done(err);}
-          wrench.copyDirSyncRecursive(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/@my-modules/sails-hook-csrf'));
+          fs.copySync(path.resolve(__dirname, 'fixtures/hooks/installable/shout'), path.resolve(__dirname,'../../testApp/node_modules/@my-modules/sails-hook-csrf'));
           fs.outputFileSync(path.resolve(__dirname,'../../testApp/node_modules/@my-modules/sails-hook-csrf/package.json'), '{"foo":<%=bar%>}');
           process.chdir(path.resolve(__dirname, "../..", appName));
           return done();

--- a/test/integration/hook.policies.test.js
+++ b/test/integration/hook.policies.test.js
@@ -8,7 +8,6 @@ var assert = require('assert');
 var httpHelper = require('./helpers/httpHelper');
 var appHelper = require('./helpers/appHelper');
 var fs = require('fs-extra');
-var wrench = require('wrench');
 
 
 
@@ -368,7 +367,7 @@ describe('router :: ', function() {
           return done(err);
         }
 
-        wrench.copyDirSyncRecursive(path.resolve(__dirname, 'fixtures/hooks/installable/add-policy'),
+        fs.copySync(path.resolve(__dirname, 'fixtures/hooks/installable/add-policy'),
           path.resolve(__dirname, '../../testApp/node_modules/sails-hook-add-policy'));
 
         process.chdir(path.resolve(__dirname, "../..", appName));

--- a/test/integration/hook.userconfig.test.js
+++ b/test/integration/hook.userconfig.test.js
@@ -5,7 +5,6 @@ var assert = require('assert');
 var httpHelper = require('./helpers/httpHelper.js');
 var appHelper = require('./helpers/appHelper');
 var util = require('util');
-var wrench = require('wrench');
 var path = require('path');
 var fs = require('fs-extra');
 var Sails = require('../../lib/app');

--- a/test/integration/hooks.user.test.js
+++ b/test/integration/hooks.user.test.js
@@ -5,7 +5,6 @@ var assert = require('assert');
 var httpHelper = require('./helpers/httpHelper.js');
 var appHelper = require('./helpers/appHelper');
 var util = require('util');
-var wrench = require('wrench');
 var path = require('path');
 var fs = require('fs-extra');
 

--- a/test/integration/new.test.js
+++ b/test/integration/new.test.js
@@ -3,8 +3,7 @@
  */
 
 var assert  = require('assert');
-var fs    = require('fs');
-var wrench  = require('wrench');
+var fs    = require('fs-extra');
 var exec  = require('child_process').exec;
 var _   = require('lodash');
 var appHelper = require('./helpers/appHelper');
@@ -28,7 +27,7 @@ describe('New app generator', function() {
   beforeEach(function(done) {
     fs.exists(appName, function(exists) {
       if (exists) {
-        wrench.rmdirSyncRecursive(appName);
+        fs.removeSync(appName);
       }
       done();
     });
@@ -37,7 +36,7 @@ describe('New app generator', function() {
   afterEach(function(done) {
     fs.exists(appName, function(exists) {
       if (exists) {
-        wrench.rmdirSyncRecursive(appName);
+        fs.removeSync(appName);
       }
       done();
     });
@@ -169,4 +168,3 @@ describe('New app generator', function() {
     });
   });
 });
-

--- a/test/integration/www.test.js
+++ b/test/integration/www.test.js
@@ -3,8 +3,7 @@
  */
 
 var assert = require('assert');
-var fs = require('fs');
-var wrench = require('wrench');
+var fs = require('fs-extra');
 var request = require('request');
 var exec = require('child_process').exec;
 var path = require('path');
@@ -19,7 +18,7 @@ describe('Running sails www', function() {
 
   before(function() {
     if (fs.existsSync(appName)) {
-      wrench.rmdirSyncRecursive(appName);
+      fs.removeSync(appName);
     }
   });
 
@@ -136,7 +135,7 @@ describe('Running sails www', function() {
 
   after(function() {
     if (fs.existsSync(appName)) {
-      wrench.rmdirSyncRecursive(appName);
+      fs.removeSync(appName);
     }
   });
 });


### PR DESCRIPTION
Since `wrench` has been [officially deprecated](https://www.npmjs.com/package/wrench#warning-this-project-is-deprecated), I have removed it in favor of `fs-extras` which is already installed in the development dependencies.

I noticed there were several `TODO` comments mentioning that this should be done, and so here is a PR to do just that!