### PR TITLE
[patch] fixes breaking changes introduced in `include-all` v1.0.1

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -248,7 +248,7 @@ module.exports = function(sails) {
             exclude   : ['locales'].concat(_.map(sails.config.moduleloader.configExt, function (extension){ return 'local.'+extension; })),
             excludeDirs: /(locales|env)$/,
             filter    : new RegExp('(.+)\\.(' + sails.config.moduleloader.configExt.join('|') + ')$'),
-            flattenDirectories: !(sails.config.dontFlattenConfig),
+            flatten: !(sails.config.dontFlattenConfig),
             identity  : false
           }, cb);
         },
@@ -271,7 +271,7 @@ module.exports = function(sails) {
             dirname   : path.resolve( sails.config.paths.config || path.resolve(sails.config.appPath, 'config'), 'env', env ),
             filter    : new RegExp('(.+)\\.(' + sails.config.moduleloader.configExt.join('|') + ')$'),
             optional  : true,
-            flattenDirectories: !(sails.config.dontFlattenConfig),
+            flatten   : !(sails.config.dontFlattenConfig),
             identity  : false
           }, cb);
         }],
@@ -286,7 +286,7 @@ module.exports = function(sails) {
             dirname   : path.resolve( sails.config.paths.config || path.resolve(sails.config.appPath, 'config'), 'env' ),
             filter    : new RegExp('^' + env + '\\.(' + sails.config.moduleloader.configExt.join('|') + ')$'),
             optional  : true,
-            flattenDirectories: !(sails.config.dontFlattenConfig),
+            flatten   : !(sails.config.dontFlattenConfig),
             identity  : false
           }, cb);
         }]
@@ -320,7 +320,7 @@ module.exports = function(sails) {
       includeAll.optional({
         dirname: sails.config.paths.controllers,
         filter: new RegExp('(.+)Controller\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
-        flattenDirectories: true,
+        flatten: true,
         keepDirectoryPath: true
       }, bindToSails(cb));
     },
@@ -336,7 +336,7 @@ module.exports = function(sails) {
         dirname: sails.config.paths.adapters,
         filter: new RegExp('(.+Adapter)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
         replaceExpr: /Adapter/,
-        flattenDirectories: true
+        flatten: true
       }, bindToSails(cb));
     },
 
@@ -352,7 +352,7 @@ module.exports = function(sails) {
         dirname   : sails.config.paths.models,
         filter    : new RegExp('^([^.]+)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
         replaceExpr : /^.*\//,
-        flattenDirectories: true
+        flatten: true
       }, function(err, models) {
         if (err) { return cb(err); }
 
@@ -361,7 +361,7 @@ module.exports = function(sails) {
           dirname   : sails.config.paths.models,
           filter    : /(.+)\.attributes.json$/,
           replaceExpr : /^.*\//,
-          flattenDirectories: true
+          flatten: true
         }, bindToSails(function(err, supplements) {
           if (err) { return cb(err); }
           return cb(null, _.merge(models, supplements));
@@ -410,7 +410,7 @@ module.exports = function(sails) {
         dirname: sails.config.paths.policies,
         filter: new RegExp('(.+)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
         replaceExpr: null,
-        flattenDirectories: true,
+        flatten: true,
         keepDirectoryPath: true
       }, bindToSails(cb));
     },


### PR DESCRIPTION
<!-- 
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact
sgress454@treeline.io

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!  
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example: 
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->


Fixes breaking changes introduced in balderdashy/include-all@821ee7848b16872920120f84bf154c331a3939e9

Because the version number in `package.json` uses `^` semver matching, version 1.0.1 is installed by default which breaks functionality on the master branch.