### PR TITLE
[patch] Allow policy targeting syntax to use function policies

### DIFF
--- a/lib/hooks/policies/index.js
+++ b/lib/hooks/policies/index.js
@@ -231,15 +231,21 @@ module.exports = function(sails) {
         return;
       }
 
-      var policyId = event.target.policy.toLowerCase();
+      var fn;
 
-      // Policy doesn't exist
-      if (!this.middleware[policyId] ) {
-        return Err.fatal.__UnknownPolicy__ (policyId, referencedIn, sails.config.paths.policies);
+      if (_.isFunction(event.target.policy)) {
+        fn = event.target.policy;
+      } else {
+        var policyId = event.target.policy.toLowerCase();
+
+        // Policy doesn't exist
+        if (!this.middleware[policyId] ) {
+          return Err.fatal.__UnknownPolicy__ (policyId, referencedIn, sails.config.paths.policies);
+        }
+
+        // Bind policy function to route
+        fn = this.middleware[policyId];
       }
-
-      // Bind policy function to route
-      var fn = this.middleware[policyId];
 
       sails.router.bind(event.path, fn, event.verb, _.merge(event.options, event.target));
     }


### PR DESCRIPTION
<!-- 
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact
sgress454@treeline.io

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!  
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example: 
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->

This patch allows routes that looks like:

```
'/foo': [{policy: somePolicyFunction}, {blueprint: 'find', model: 'user'}]
```

(from documentation here: http://sailsjs.org/documentation/concepts/routes/custom-routes#?policy-target-syntax)

Before the patch, policies used in this format had to be strings, as `toLowerCase` was called on them before checking the type. However, the `config/policies.js` file allows policies to be functions as well as strings.
