### PR TITLE
[implements #3142] built-in server-side typescript support (+ literate iced babel coffee live everything)

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -6,7 +6,6 @@ module.exports = function(sails) {
   var path = require('path');
   var async = require('async');
   var _ = require('@sailshq/lodash');
-  var walk = require('walk');
   var includeAll = require('include-all');
 
 
@@ -63,143 +62,27 @@ module.exports = function(sails) {
           // For `views` hook
           views: path.resolve(config.appPath, 'views'),
           layout: path.resolve(config.appPath, 'views/layout.ejs')
-        },
-
-
-        moduleloader: {
-          // configExt and sourceExt will be changed in Sails v1
-          // (probably unified into a single config)
-          configExt: undefined,
-          sourceExt: undefined
-        },
-
-        // `sails.config.moduleLoaderOverride` will be deprecated in Sails v1.
-        moduleLoaderOverride: undefined
+        }
 
       };
-
-      var conf = localConfig.moduleloader;
-
-      // Declare supported languages.
-      // To add another language use the format below.
-      // {
-      //   extensions: An array of file extensions supported by this module
-      //   module: the NPM module name
-      //   require: the require statement
-      // }
-      var supportedLangs = [
-        {
-          extensions: ['iced','liticed'],
-          module: 'iced-coffee-script',
-          require: 'iced-coffee-script/register'
-        },
-        {
-          extensions: ['coffee','litcoffee'],
-          module: 'coffee-script',
-          require: 'coffee-script/register'
-        },
-        {
-          extensions: ['ls'],
-          module: 'LiveScript',
-          require: 'livescript'
-        }
-      ];
-
-      var detectedLangs = [];
-      var detectedExtens = [];
-
-      // Options for `walk`
-      var walkOpts = {
-        listeners: {
-          // This function runs once for every found file when
-          // we walk the directory tree
-          file: function (root, fileStats, next) {
-            var fileName = fileStats.name;
-            var extens = path.extname(fileName).substring(1);
-
-            // Look for every file extension we support and flag the appropriate language
-            _.forEach(supportedLangs, function(lang){
-              // If we have already found a language, skip it.
-              if (!_.contains(detectedLangs, lang.module)) {
-                // If we find a new one, add it to the list.
-                if (_.contains(lang.extensions, extens)) {
-                  detectedLangs.push(lang.module);
-                }
-              }
-            });
-
-            next();
-          },
-          errors: function (root, nodeStatsArray, next) {
-            next();
-          },
-        },
-
-        // Do not detect languages from node_modules/ directories
-        // which might be embedded within app.
-        filters: ['node_modules'],
-      };
-
-      // Walk the /api and /config directories
-      walk.walkSync(path.resolve(localConfig.appPath,'api'), walkOpts);
-      walk.walkSync(path.resolve(localConfig.appPath, 'config'), walkOpts);
-
-      // ----------------------------------------------------------------------
-      // This slows down lift time **a lot** (~500ms on medium-sized app
-      // when lifting on MacOS X with an SSD).  This should be pulled out
-      // of core and provided as a hook. The hook API might need to be
-      // extended to allow this to be done gracefully.
-      // ----------------------------------------------------------------------
-
-      sails.log.verbose('In this Sails app, detected special code languages:',detectedLangs.length, detectedLangs);
-      sails.log.silly('(and detected %d special file extensions:',detectedExtens.length, detectedExtens,')');
-
-      // Check for which languages were found and load the necessary modules to compile them
-      _.forEach(detectedLangs, function(moduleName){
-        var lang = _.find(supportedLangs, {module: moduleName});
-        detectedExtens = detectedExtens.concat(lang.extensions);
-
-        // Try to require the language extension module directly.
-        // (this only works if the dep is installed in the $HOME directory,
-        //  or if we catch a lucky break)
-        try {
-          require(lang.require);
-        } catch(e0){
-
-          // If that doesn't work, then try to require the language extension module
-          // by building a path directly to where it _should_ be installed as one of
-          // this app's local dependencies.
-          try {
-            require(path.join(localConfig.appPath, 'node_modules', lang.require));
-          }
-          catch (e1) {
-            sails.log.error('Please run `npm install '+lang.module+'` to use '+lang.module+'!');
-            sails.log.silly('Here\'s the require error(s): ',e0,e1);
-          }
-        }
-      });
-
-      conf.configExt = ['js','json'].concat(detectedExtens);
-      conf.sourceExt = ['js'].concat(detectedExtens);
 
       return localConfig;
     },
 
     initialize: function(cb) {
-      // Expose self as `sails.modules` (for backwards compatibility)
+      // Expose self as `sails.modules`.
       sails.modules = sails.hooks.moduleloader;
+      // |
+      // |_Note that, in the future, the moduleloader's methods will be federated
+      // | out to the places where they're being used, instead of relying on
+      // | having those other modules call the appropriate method on `sails.modules.*()`.
 
       return cb();
     },
 
     configure: function() {
-      if (sails.config.moduleLoaderOverride) {
-        var override = sails.config.moduleLoaderOverride(sails, this);
-        _.extend(this, override);
-        if (override.configure) {
-          this.configure();
-        }
-      }
+
+      // Default to process.cwd()
       sails.config.appPath = sails.config.appPath ? path.resolve(sails.config.appPath) : process.cwd();
 
       _.extend(sails.config.paths, {
@@ -246,10 +129,20 @@ module.exports = function(sails) {
       async.auto({
         'config/*': function loadOtherConfigFiles (cb) {
           includeAll.aggregate({
+            // TODO: change this to use `sails.config.paths.config` instead
             dirname   : sails.config.paths.config || path.resolve(sails.config.appPath, 'config'),
-            exclude   : ['locales'].concat(_.map(sails.config.moduleloader.configExt, function (extension){ return 'local.'+extension; })),
+            exclude   : ['locales', 'local.js'],
+            // ===========================================================
+            // NOTE:
+            // `config/local.js` has special, precedent-taking properties.
+            // Because of this, it is excluded here to avoid running twice
+            // (since iinclude-all clears the require cache).  But note that
+            // if you are using `local.ts`, etc., then it will still take
+            // precedence, but IT WILL ALSO BE REQUIRED TWICE!!  Be sure not
+            // to do anything non-idempotent in your `local.*` config file.
+            // =======================================================
             excludeDirs: /(locales|env)$/,
-            filter    : new RegExp('(.+)\\.(' + sails.config.moduleloader.configExt.join('|') + ')$'),
+            filter    : /(.+)\..+$/,
             flatten   : true,
             keepDirectoryPath: true,
             identity  : false
@@ -258,8 +151,9 @@ module.exports = function(sails) {
 
         'config/local' : function loadLocalOverrideFile (cb) {
           includeAll.aggregate({
+            // TODO: change this to use `sails.config.paths.config` instead
             dirname   : sails.config.paths.config || path.resolve(sails.config.appPath, 'config'),
-            filter    : new RegExp('local\\.(' + sails.config.moduleloader.configExt.join('|') + ')$'),
+            filter    : /local\..+$/,
             identity  : false
           }, cb);
         },
@@ -271,8 +165,9 @@ module.exports = function(sails) {
           // for an environment setting.  Lastly, default to development.
           var env = sails.config.environment || async_data['config/local'].environment || 'development';
           includeAll.aggregate({
+            // TODO: change this to use `sails.config.paths.config` instead
             dirname   : path.resolve( sails.config.paths.config || path.resolve(sails.config.appPath, 'config'), 'env', env ),
-            filter    : new RegExp('(.+)\\.(' + sails.config.moduleloader.configExt.join('|') + ')$'),
+            filter    : /(.+)\..+$/,
             optional  : true,
             flatten   : true,
             keepDirectoryPath: true,
@@ -287,8 +182,9 @@ module.exports = function(sails) {
           // for an environment setting.  Lastly, default to development.
           var env = sails.config.environment || async_data['config/local'].environment || 'development';
           includeAll.aggregate({
+            // TODO: change this to use `sails.config.paths.config` instead
             dirname   : path.resolve( sails.config.paths.config || path.resolve(sails.config.appPath, 'config'), 'env' ),
-            filter    : new RegExp('^' + env + '\\.(' + sails.config.moduleloader.configExt.join('|') + ')$'),
+            filter    : new RegExp('^' + _.escapeRegExp(env) + '\\..+$'),
             optional  : true,
             flatten   : true,
             keepDirectoryPath: true,
@@ -324,7 +220,7 @@ module.exports = function(sails) {
     loadControllers: function (cb) {
       includeAll.optional({
         dirname: sails.config.paths.controllers,
-        filter: new RegExp('(.+)Controller\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
+        filter: /(.+)Controller\..+$/,
         flatten: true,
         keepDirectoryPath: true
       }, bindToSails(cb));
@@ -339,7 +235,7 @@ module.exports = function(sails) {
     loadAdapters: function (cb) {
       includeAll.optional({
         dirname: sails.config.paths.adapters,
-        filter: new RegExp('(.+Adapter)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
+        filter: /(.+Adapter)\..+$/,
         replaceExpr: /Adapter/,
         flatten: true
       }, bindToSails(cb));
@@ -355,12 +251,13 @@ module.exports = function(sails) {
       // Get the main model files
       includeAll.optional({
         dirname   : sails.config.paths.models,
-        filter    : new RegExp('^([^.]+)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
+        filter    : /^([^.]+)\..+$/,
         replaceExpr : /^.*\//,
         flatten: true
       }, function(err, models) {
         if (err) { return cb(err); }
 
+        // ---------------------------------------------------------
         // Get any supplemental files
         includeAll.optional({
           dirname   : sails.config.paths.models,
@@ -369,8 +266,15 @@ module.exports = function(sails) {
           flatten: true
         }, bindToSails(function(err, supplements) {
           if (err) { return cb(err); }
+
+          if (_.keys(supplements).length > 0) {
+            // TODO: Log deprecation warning, a la:
+            // sails.log.debug('The use of `.attributes.json` files is deprecated, and support will be removed in a future release of Sails.');
+          }//>-
+
           return cb(null, _.merge(models, supplements));
         }));
+        // ---------------------------------------------------------
       });
     },
 
@@ -383,7 +287,7 @@ module.exports = function(sails) {
     loadServices: function (cb) {
       includeAll.optional({
         dirname     : sails.config.paths.services,
-        filter      : new RegExp('(.+)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
+        filter      : /(.+)\..+$/,
         depth     : 1,
         caseSensitive : true
       }, bindToSails(cb));
@@ -413,7 +317,7 @@ module.exports = function(sails) {
     loadPolicies: function (cb) {
       includeAll.optional({
         dirname: sails.config.paths.policies,
-        filter: new RegExp('(.+)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
+        filter: /(.+)\..+$/,
         replaceExpr: null,
         flatten: true,
         keepDirectoryPath: true
@@ -435,7 +339,7 @@ module.exports = function(sails) {
         hooksFolder: function(cb) {
           includeAll.optional({
             dirname: sails.config.paths.hooks,
-            filter: new RegExp('^(.+)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
+            filter: /^(.+)\..+$/,
 
             // Hooks should be defined as either single files as a function
             // OR (better yet) a subfolder with an index.js file
@@ -580,8 +484,11 @@ module.exports = function(sails) {
             // Load the hook code
             var hook = require(path.resolve(sails.config.appPath, 'node_modules', identity));
 
+            // TODO: Sails v1: Remove this and any other support for the `configKey` property
+            // ------------------------------------------------------------------
             // Set its config key (defaults to the hook name)
             hook.configKey = (sails.config.installedHooks && sails.config.installedHooks[identity] && sails.config.installedHooks[identity].configKey) || hookName;
+            // ------------------------------------------------------------------
 
             // Add this to the list of hooks to load
             memo[hookName] = hook;
@@ -604,7 +511,7 @@ module.exports = function(sails) {
     loadBlueprints: function (cb) {
       includeAll.optional({
         dirname: sails.config.paths.blueprints,
-        filter: new RegExp('(.+)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
+        filter: /(.+)\..+$/,
         useGlobalIdForKeyName: true
       }, cb);
     },
@@ -618,7 +525,7 @@ module.exports = function(sails) {
     loadResponses: function (cb) {
       includeAll.optional({
         dirname: sails.config.paths.responses,
-        filter: new RegExp('(.+)\\.(' + sails.config.moduleloader.sourceExt.join('|') + ')$'),
+        filter: /(.+)\..+$/,
         useGlobalIdForKeyName: true
       }, bindToSails(cb));
     },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "sort-route-addresses": "^0.0.1",
     "uid-safe": "1.1.0",
     "vary": "1.1.0",
-    "walk": "2.3.9",
     "waterline-criteria": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Implements https://github.com/balderdashy/sails/pull/3142#issuecomment-247690755 (see also https://github.com/balderdashy/sails/pull/3142#issuecomment-247690755). This commit also adds TODOs re a deprecation warning for '.attributes.json' files, for switching to consistently using 'sails.config.paths.config', and for pulling out all built-in support for the 'configKey' hook property (and related documentation- see http://sailsjs.org/documentation/concepts/extending-sails/hooks/using-hooks#?changing-the-way-sails-loads-an-installable-hook). to [implements #3142] built-in server-side typescript support (+ literate iced babel coffee live everything)