### PR TITLE
[patch] Fixes, comments, and clarifications in actions2 implementation.  This also stubs out some todos.

### DIFF
--- a/lib/app/load.js
+++ b/lib/app/load.js
@@ -53,7 +53,7 @@ module.exports = function(sails) {
       hooks: ['config', loadHooks],
 
       // Load actions from disk and config overrides
-      controller: ['hooks', sails._controller.loadModules],
+      controller: ['hooks', sails._controller.loadActionModules],
       // Populate the "registry"
       // Houses "middleware-esque" functions bound by various hooks and/or Sails core itself.
       // (i.e. `function (req, res [,next]) {}`)

--- a/lib/app/private/controller/README.md
+++ b/lib/app/private/controller/README.md
@@ -28,7 +28,7 @@ Action middleware are functions that are intended to _modify_ actions (or more a
 
 ### Private methods
 
-##### `Sails.controller.loadModules(cb)`
+##### `Sails.controller.loadActionModules(cb)`
 
 When Sails loads, this method loads all of the files underneath the controllers directory (`api/controllers` by default) and attempts to parse them into actions that can be bound to routes.  File in the controllers directory can either be pascal-cased and ending in "Controller" (e.g. MyController.js), in which case they are expected to be _dictionaries_ of actions, or else kebab-cased and lowercased (e.g. my-action.js) in which case they are expected to contain a single action.  An action may be a function which accepts `req` and `res` as arguments, or a [node-machine](http://node-machine.org) definition which will be parsed by [machine-as-action](https://github.com/treelinehq/machine-as-action).
 

--- a/lib/app/private/controller/README.md
+++ b/lib/app/private/controller/README.md
@@ -1,6 +1,6 @@
 # Actions in Sails
 
-In Sails, an _action_ is a named request handler that is intended to be bound directly to a route in an app's `config/routes.js` file.  Actions may be loaded from disk (typically from the `api/controllers` project folder and subfolders), or added by hooks (using `sails.registerAction`).
+In Sails, an _action_ is a named request handler that is intended to be bound directly to a route in an app's `config/routes.js` file.  Actions may be loaded from disk (typically from the `api/controllers` project folder and subfolders), from runtime configuration (in `sails.config.controllers.moduleDefinitions`) or added by hooks (using `sails.registerAction`).
 
 ##### Benefits of actions
 
@@ -32,7 +32,7 @@ Action middleware are functions that are intended to _modify_ actions (or more a
 
 When Sails loads, this method loads all of the files underneath the controllers directory (`api/controllers` by default) and attempts to parse them into actions that can be bound to routes.  File in the controllers directory can either be pascal-cased and ending in "Controller" (e.g. MyController.js), in which case they are expected to be _dictionaries_ of actions, or else kebab-cased and lowercased (e.g. my-action.js) in which case they are expected to contain a single action.  An action may be a function which accepts `req` and `res` as arguments, or a [node-machine](http://node-machine.org) definition which will be parsed by [machine-as-action](https://github.com/treelinehq/machine-as-action).
 
-After actions are loaded from disk, any actions specified under the `sails.config.controllers.actions` config key are merged on top of those actions.  This allows Sails apps to be constructed dynamically at runtime.
+After actions are loaded from disk, any actions specified under the `sails.config.controllers.moduleDefinitions` config key are merged on top of those actions.  This allows Sails apps to be constructed dynamically at runtime.
 
 Note that this method is called internally by Sails _after_ hooks have loaded (or in the case of a `Sails.reloadModules` call, after they have _reloaded_).  This ensures that user actions always take precedence over those added by hooks.
 

--- a/lib/app/private/controller/README.md
+++ b/lib/app/private/controller/README.md
@@ -1,6 +1,6 @@
 # Actions in Sails
 
-In Sails, an _action_ is a named request handler that is intended to be bound directly to a route in an app's `config/routes.js` file.  Actions may be loaded from disk (typically from the `api/controllers` project folder and subfolders), from runtime configuration (in `sails.config.controllers.actions`) or added by hooks (using `sails.registerAction`).
+In Sails, an _action_ is a named request handler that is intended to be bound directly to a route in an app's `config/routes.js` file.  Actions may be loaded from disk (typically from the `api/controllers` project folder and subfolders), or added by hooks (using `sails.registerAction`).
 
 ##### Benefits of actions
 

--- a/lib/app/private/controller/README.md
+++ b/lib/app/private/controller/README.md
@@ -24,31 +24,15 @@ Somewhere in the middle lie hooks that create a request handler that you may wan
 
 Action middleware are functions that are intended to _modify_ actions (or more accurately, the requests that the actions handle).  You may register middleware that affects a single action, a subset of actions, or all actions.  Note that action middleware _only_ affects actions; if you need to modify _all_ requests (particularly, if you need to modify requests that return assets), you should still bind a route directly to `/*` in your hook.
 
-# Action-related methods in Sails
 
-### Private methods
 
-##### `Sails.controller.loadActionModules(cb)`
-
-When Sails loads, this method loads all of the files underneath the controllers directory (`api/controllers` by default) and attempts to parse them into actions that can be bound to routes.  File in the controllers directory can either be pascal-cased and ending in "Controller" (e.g. MyController.js), in which case they are expected to be _dictionaries_ of actions, or else kebab-cased and lowercased (e.g. my-action.js) in which case they are expected to contain a single action.  An action may be a function which accepts `req` and `res` as arguments, or a [node-machine](http://node-machine.org) definition which will be parsed by [machine-as-action](https://github.com/treelinehq/machine-as-action).
-
-After actions are loaded from disk, any actions specified under the `sails.config.controllers.moduleDefinitions` config key are merged on top of those actions.  This allows Sails apps to be constructed dynamically at runtime.
-
-Note that this method is called internally by Sails _after_ hooks have loaded (or in the case of a `Sails.reloadModules` call, after they have _reloaded_).  This ensures that user actions always take precedence over those added by hooks.
-
-##### `Sails.controller.loadAction(action, identity, [force])`
-
-This method takes an _action_ (in the form of a function or a machine definition, which is transformed into a function via `machine-as-action`) and adds it to the internal `Sails._actions` dictionary under the key specified by `identity`.  Keys in the internal dictionary can be overridden by setting the `force` argument to `true`; otherwise any conflict will result in an error being thrown.
-
-##### `Sails.controller.bindRoute(route)`
-
-Called directly by the Sails `router.bind` method in order to handle route syntax like `{controller: 'MyController', action: 'myAction'}` and `{action: 'some-action'}`.
+## Action-related methods in Sails
 
 ### Public methods
 
 ##### `sails.registerAction(action, identity)`
 
-Registers an action in Sails.  It is very similar in function to the private `loadAction` method, with the notable exception that there is no `force` argument: if a call to `registerAction` results in an attempt to overwrite an existing key in the actions dictionary, the call will trigger an error with code `E_CONFLICT`.
+Registers an action in Sails.  It is very similar in function to the private `registerAction` method, with the notable exception that there is no `force` argument: if a call to `registerAction` results in an attempt to overwrite an existing key in the actions dictionary, the call will trigger an error with code `E_CONFLICT`.
 
 ##### `sails.getActions()`
 
@@ -62,7 +46,7 @@ Examples:
 
 **Register middleware that affects all actions**:
 ```
-sails.registerActionMiddleware(mustBeLoggedIn, '*'
+sails.registerActionMiddleware(mustBeLoggedIn, '*')
 ````
 
 **Register middleware that affects all `user` actions**:
@@ -85,5 +69,22 @@ sails.registerActionMiddleware(mustBeLoggedIn, ['user.*', 'pet.*'], 'user.hello'
 sails.registerActionMiddleware(mustBeLoggedIn, ['user.*', 'pet.*'], ['user.public.*', 'pet.public.*'])
 ````
 
+
+
+### Private utilities
+
+> _Please do not use these in a hook (even a core hook) or in any userland code!  They may change at any time, without warning!_
+
+##### `loadActionModules()`
+
+When Sails loads, this method loads all of the files underneath the controllers directory (`api/controllers` by default) and attempts to parse them into actions that can be bound to routes.  File in the controllers directory can either be pascal-cased and ending in "Controller" (e.g. MyController.js), in which case they are expected to be _dictionaries_ of actions, or else kebab-cased and lowercased (e.g. my-action.js) in which case they are expected to contain a single action.  An action may be a function which accepts `req` and `res` as arguments, or a [node-machine](http://node-machine.org) definition which will be parsed by [machine-as-action](https://github.com/treelinehq/machine-as-action).
+
+After actions are loaded from disk, any actions specified under the `sails.config.controllers.moduleDefinitions` config key are merged on top of those actions.  This allows Sails apps to be constructed dynamically at runtime.
+
+Note that this method is called internally by Sails _after_ hooks have loaded (or in the case of a `Sails.reloadModules` call, after they have _reloaded_).  This ensures that user actions always take precedence over those added by hooks.
+
+##### `helpRegisterAction(action, identity, [force])`
+
+This method takes an _action_ (in the form of a function or a machine definition, which is transformed into a function via `machine-as-action`) and adds it to the internal `Sails._actions` dictionary under the key specified by `identity`.  Keys in the internal dictionary can be overridden by setting the `force` argument to `true`; otherwise any conflict will result in an error being thrown.
 
 

--- a/lib/app/private/controller/help-register-action.js
+++ b/lib/app/private/controller/help-register-action.js
@@ -7,20 +7,31 @@ var machineAsAction = require('machine-as-action');
 
 
 /**
- * registerAction()
+ * helpRegisterAction()
  *
+ * @param  {SailsApp} sails
  * @param  {Function|Dictionary} action   [either a req/res function, or an actions2 (i.e. machine-as-action) definition]
  * @param  {String} identity   [the identity to register this action as]
  * @param  {Boolean} force
  *
  * @throws {Error} If there is a conflicting, previously-registered action
  *         @property {String} code (==='E_CONFLICT')
+ *         @property {String} identity  [the conflicting identity (always the same as what was passed in)]
+ *
+ * @throws {Error} If the action is invalid
+ *         @property {String} code (==='E_INVALID')
+ *         @property {String} identity  [the action identity (always the same as what was passed in)]
+ *         @property {Error} origError  [the original (raw/underlying) error from `machine-as-action`]
  */
 
-module.exports = function registerAction(action, identity, force) {
+module.exports = function helpRegisterAction(sails, action, identity, force) {
+
+  if (!_.isObject(sails) || !_.isObject(sails._actions)) {
+    throw new Error('Consistency violation: helpRegisterAction() expects `sails` (a Sails app instance) to be passed in as the first argument.');
+  }
 
   // Get a reference to the Sails private actions hash.
-  var actions = this._actions;
+  var actions = sails._actions;
 
   // Make sure identity is lowercased.
   identity = identity.toLowerCase();
@@ -51,7 +62,7 @@ module.exports = function registerAction(action, identity, force) {
     }
     // If a machine couldn't be built from the action, bail.
     catch (e) {
-      var invalidError = new Error('The action `' + actionName + '` in file `' + filePath + '` is invalid.  It looks like a machine definition, but it could not be used to build a machine.\nThe error returned was: "'+e+'"');
+      var invalidError = new Error('The action `' + identity + '` could not be registered.  It looks like a machine definition (actions2), but it could not be used to build an action.\nDetails: '+e.stack);
       invalidError.code = 'E_INVALID';
       invalidError.identity = identity;
       invalidError.origError = e;
@@ -59,8 +70,8 @@ module.exports = function registerAction(action, identity, force) {
     }
   }
 
-  // Set the _middlewareType, which is used in the silly output to
-  // identity what kind of a thing a route is bound to.
+  // Set the _middlewareType, which is used when the log level is "silly" to
+  // identify what kind of a thing a route address is bound to.
   actions[identity]._middlewareType = actions[identity]._middlewareType || 'ACTION: ' + identity;
 
 };

--- a/lib/app/private/controller/help-register-action.js
+++ b/lib/app/private/controller/help-register-action.js
@@ -2,6 +2,8 @@
  * Module dependencies
  */
 
+var util = require('util');
+var assert = require('assert');
 var _ = require('@sailshq/lodash');
 var machineAsAction = require('machine-as-action');
 
@@ -26,9 +28,9 @@ var machineAsAction = require('machine-as-action');
 
 module.exports = function helpRegisterAction(sails, action, identity, force) {
 
-  if (!_.isObject(sails) || !_.isObject(sails._actions)) {
-    throw new Error('Consistency violation: helpRegisterAction() expects `sails` (a Sails app instance) to be passed in as the first argument.');
-  }
+  assert(_.isObject(sails) && _.isObject(sails._actions), new Error('Consistency violation: `sails` (a Sails app instance) should be passed in as the first argument.'));
+  assert(_.isFunction(action) || _.isObject(action), new Error('Consistency violation: `action` (2nd arg) should be provided as either a req/res/next function or a machine def (actions2), but instead, got: '+util.inspect(action,{depth:null})));
+  assert(_.isString(identity), new Error('Consistency violation: Identity should be provided as a string, but instead, got: '+util.inspect(identity,{depth:null})));
 
   // Get a reference to the Sails private actions hash.
   var actions = sails._actions;

--- a/lib/app/private/controller/index.js
+++ b/lib/app/private/controller/index.js
@@ -3,8 +3,8 @@
  */
 
 var _ = require('@sailshq/lodash');
-var registerAction = require('./register-action');
-var loadModules = require('./load-modules');
+var helpRegisterAction = require('./help-register-action');
+var loadActionModules = require('./load-action-modules');
 
 
 /**
@@ -15,13 +15,13 @@ var loadModules = require('./load-modules');
  *
  * @param  {SailsApp} sails
  * @return {Dictionary}
- *         @property {Function} registerAction
- *         @property {Function} loadModules
+ *         @property {Function} helpRegisterAction
+ *         @property {Function} loadActionModules
  */
 
 module.exports = function todo(sails) {
   return {
-    registerAction: _.bind(registerAction, sails),
-    loadModules: _.bind(loadModules, sails)
+    helpRegisterAction: _.bind(helpRegisterAction, sails),
+    loadActionModules: _.bind(loadActionModules, sails)
   };
 };

--- a/lib/app/private/controller/index.js
+++ b/lib/app/private/controller/index.js
@@ -1,8 +1,27 @@
-var _ = require('@sailshq/lodash');
+/**
+ * Module dependencies
+ */
 
-module.exports = function(sails) {
+var _ = require('@sailshq/lodash');
+var registerAction = require('./register-action');
+var loadModules = require('./load-modules');
+
+
+/**
+ * todo()
+ *
+ * TODO: replace this in favor of using these underlying methods statelessly
+ * where they're needed (and instead of relying on context, pass in `sails` as the final argument)
+ *
+ * @param  {SailsApp} sails
+ * @return {Dictionary}
+ *         @property {Function} registerAction
+ *         @property {Function} loadModules
+ */
+
+module.exports = function todo(sails) {
   return {
-    registerAction: _.bind(require('./register-action'), sails),
-    loadModules: _.bind(require('./load-modules'), sails)
+    registerAction: _.bind(registerAction, sails),
+    loadModules: _.bind(loadModules, sails)
   };
 };

--- a/lib/app/private/controller/load-action-modules.js
+++ b/lib/app/private/controller/load-action-modules.js
@@ -5,15 +5,26 @@
 var path = require('path');
 var _ = require('@sailshq/lodash');
 var includeAll = require('include-all');
+var flaverr = require('flaverr');
+var helpRegisterAction = require('./help-register-action');
 
 
-module.exports = function (results, cb) {
+/**
+ * loadActionModules()
+ *
+ * @param  {[type]}   results [description]
+ * @param  {Function} cb      [description]
+ * @return {[type]}           [description]
+ */
+module.exports = function loadActionModules (results, cb) {
 
   var sails = this;
 
   // Since this may be called from an async.auto() where it has dependencies,
   // we need to support the `results, cb` signature.  But it also may be
   // called directly, so we need to make sure `results` is optional.
+  //
+  // TODO: remove this (we should use a wrapping function at wherever this is getting called from async.auto anyway)
   if (_.isFunction(results)) {
     cb = results;
   }
@@ -32,13 +43,17 @@ module.exports = function (results, cb) {
     keepDirectoryPath: true
   }, function(err, files) {
     if (err) { return cb(err); }
-    // Set up a var to hold a list of invalid files.
-    var garbage = [];
-    // Traditional controllers are PascalCased and end with the word "Controller".
-    var traditionalRegex = new RegExp('^((?:(?:.*)/)*([0-9A-Z][0-9a-zA-Z_]*))Controller\\..+$');
-    // Actions are kebab-cased.
-    var actionRegex = new RegExp('^((?:(?:.*)/)*([a-z][a-z0-9-]*))\\..+$');
+
     try {
+
+      // Set up a var to hold a list of invalid files.
+      var garbage = [];
+      // Traditional controllers are PascalCased and end with the word "Controller".
+      var traditionalRegex = new RegExp('^((?:(?:.*)/)*([0-9A-Z][0-9a-zA-Z_]*))Controller\\..+$');
+      // Actions are kebab-cased.
+      var actionRegex = new RegExp('^((?:(?:.*)/)*([a-z][a-z0-9-]*))\\..+$');
+
+
       // Loop through all of the files returned from include-all.
       _.each(files, function(module) {
         var filePath = module.globalId;
@@ -76,11 +91,31 @@ module.exports = function (results, cb) {
               conflictError.identity = actionIdentity;
               throw conflictError;
             }
+
             // Attempt to load the action into our set of actions.
-            // This may throw an error, which will be caught below.
-            sails._controller.registerAction(action, actionIdentity, true);
+            // Since the following code might throw E_CONFLICT errors, we'll inject a `try` block here
+            // to intercept them and wrap the Error.
+            try {
+              helpRegisterAction(sails, action, actionIdentity, true);
+            } catch (e) {
+              switch (e.code) {
+
+                case 'E_CONFLICT':
+                  // Improve error message with addtl contextual information about where this action came from.
+                  // (plus a slightly better stack trace)
+                  throw flaverr({
+                    code: 'E_CONFLICT', identity: actionIdentity },
+                    new Error('Failed to register `' + actionName + '`, an action in the controller loaded from `'+filePath+'` because it conflicts with a previously-registered action.')
+                  );
+
+                default:
+                  throw e;
+              }
+            }//</catch>
+
             // Flag that an action with the given identity was successfully loaded from disk.
             actionsLoadedFromDisk[actionIdentity] = true;
+
           });
         } // </ is it a traditional controller? >
 
@@ -98,11 +133,30 @@ module.exports = function (results, cb) {
             conflictError.identity = actionIdentity;
             throw conflictError;
           }
+
           // Attempt to load the action into our set of actions.
           // This may throw an error, which will be caught below.
-          sails._controller.registerAction(module, actionIdentity, true);
+          try {
+            helpRegisterAction(sails, module, actionIdentity, true);
+          }
+          catch (e) {
+            switch (e.code) {
+
+              case 'E_CONFLICT':
+                // Improve error message with addtl contextual information about where this action came from.
+                throw flaverr({
+                  code: 'E_CONFLICT', identity: actionIdentity },
+                  new Error('Failed to register `' + actionName + '`, an action loaded from `'+filePath+'` because it conflicts with a previously-registered action.')
+                );
+
+              default:
+                throw e;
+            }
+          }//</catch>
+
           // Flag that an action with the given identity was successfully loaded from disk.
           actionsLoadedFromDisk[actionIdentity] = true;
+
         } // </ is it an action?>
 
         // Otherwise give up on this file, it's GARBAGE.
@@ -114,29 +168,46 @@ module.exports = function (results, cb) {
 
       }); // </each(file from includeAll)>
 
-    // If any errors were thrown above (probably in the `loadAction` calls),
-    // we'll catch them here.
+
+      // Complain about garbage.
+      if (garbage.length) {
+        sails.log.warn('---------------------------------------------------------------------------');
+        sails.log.warn('Files in the `controllers` directory may be traditional controllers or \n' +
+                     'action files.  Traditional controllers are dictionaries of actions, with \n' +
+                     'pascal-cased filenames ending in "Controller" (e.g. MyGreatController.js).\n' +
+                     'Action files are kebab-cased (e.g. do-stuff.js) and contain a single action.\n'+
+                     'The following file'+(garbage.length > 1 ? 's were' : ' was')+' ignored for not meeting those criteria:');
+        _.each(garbage, function(filePath){sails.log.warn('- '+filePath);});
+        sails.log.warn('----------------------------------------------------------------------------\n');
+      }
+
+      // (Shallow) merge stuff from sails.config.controllers.moduleDefinitions on top of any loaded files.
+      _.each(_.get(sails, 'config.controllers.moduleDefinitions') || {}, function(action, actionIdentity) {
+
+        // This could throw an E_CONFLICT error, so we explicitly intercept it in order to provide a more
+        // contextual error message/stack/etc.
+        try {
+          helpRegisterAction(sails, action, actionIdentity, true);
+        } catch (e) {
+          switch (e.code) {
+
+            case 'E_CONFLICT':
+              // Improve error message with addtl contextual information about where this action came from.
+              throw flaverr({
+                code: 'E_CONFLICT', identity: actionIdentity },
+                new Error('Failed to register `' + actionName + '`, an action loaded from `sails.config.controllers.moduleDefinitions`, because it conflicts with a previously-registered action.')
+              );
+
+            default:
+              throw e;
+          }
+        }//</catch>
+      });//</each programmatically declared action from `sails.config.controllers.moduleDefinitions`>
+
+      // All done.
+      return cb();
+
     } catch (e) { return cb(e); }
-
-    // Complain about garbage.
-    if (garbage.length) {
-      sails.log.warn('---------------------------------------------------------------------------');
-      sails.log.warn('Files in the `controllers` directory may be traditional controllers or \n' +
-                   'action files.  Traditional controllers are dictionaries of actions, with \n' +
-                   'pascal-cased filenames ending in "Controller" (e.g. MyGreatController.js).\n' +
-                   'Action files are kebab-cased (e.g. do-stuff.js) and contain a single action.\n'+
-                   'The following file'+(garbage.length > 1 ? 's were' : ' was')+' ignored for not meeting those criteria:');
-      _.each(garbage, function(filePath){sails.log.warn('- '+filePath);});
-      sails.log.warn('----------------------------------------------------------------------------\n');
-    }
-
-    // Merge stuff from sails.config.controllers.moduleDefinitions on top of any loaded files.
-    _.each(_.get(sails, 'config.controllers.moduleDefinitions') || {}, function(action, actionIdentity) {
-      sails._controller.registerAction(action, actionIdentity, true);
-    });
-
-    return cb();
-
   }); // </includeAll>
 
 };

--- a/lib/app/private/controller/register-action.js
+++ b/lib/app/private/controller/register-action.js
@@ -1,5 +1,21 @@
+/**
+ * Module dependencies
+ */
+
 var _ = require('@sailshq/lodash');
 var machineAsAction = require('machine-as-action');
+
+
+/**
+ * registerAction()
+ *
+ * @param  {Function|Dictionary} action   [either a req/res function, or an actions2 (i.e. machine-as-action) definition]
+ * @param  {String} identity   [the identity to register this action as]
+ * @param  {Boolean} force
+ *
+ * @throws {Error} If there is a conflicting, previously-registered action
+ *         @property {String} code (==='E_CONFLICT')
+ */
 
 module.exports = function registerAction(action, identity, force) {
 

--- a/lib/app/private/loadHooks.js
+++ b/lib/app/private/loadHooks.js
@@ -107,7 +107,8 @@ module.exports = function(sails) {
       });
     }
 
-    async.series({
+    async.series(
+      {
 
         // First load the moduleloader (if any)
         moduleloader: function(cb) {
@@ -187,6 +188,7 @@ module.exports = function(sails) {
 
       function hooksReady(err) {
         return cb(err);
-      });
+      }
+    );//</async.series>
   };
 };

--- a/lib/app/register-action-middleware.js
+++ b/lib/app/register-action-middleware.js
@@ -1,38 +1,57 @@
 /**
+ * Module dependencies
+ */
+
+var _ = require('@sailshq/lodash');
+
+
+/**
  * Sails.prototype.registerActionMiddleware()
  *
  * Register an action middleware with Sails.
  *
- * Action middleware runs before the action or actions
- * specified by the middleware key.
+ * > Action middleware runs before the action or actions specified by the `actionsGlobKey`.
  *
- * @param {fn} middleware The function to register
- * @param {string} actions The identity of the action or actions that this middleware should apply to.
- *                         Use * at the end for a wildcard; e.g. `user.*` will apply to any actions
- *                         whose identity begins with `user.`.
+ * -------------------------------------------------------------------------------------------
+ * @param {Function|Array} middleware
+ *        The `(req,res,next)` function to register, or an array of such functions.
  *
+ * @param {String} actionsGlobKey
+ *        A special, limited glob expression that indicates the action or actions that
+ *        this action middleware should apply to.  Use * at the end for a wildcard;
+ *        e.g. `user.*` will apply to any actions whose identities begin with `user.`.
+ *
+ * @context {SailsApp}
  *
  * @api public
  */
-module.exports = function registerAction(middleware, actions) {
 
-  // TODO -- update machine-as-action with a response type that calls `next`,
-  // so machine defs can be registered as middleware?
+module.exports = function registerActionMiddleware(middleware, actionsGlobKey) {
+
+  var sails = this;
+
+  // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+  // FUTURE: explore how we might extend machine-as-action or implement
+  // something entirely new (e.g. `machine-as-middleware`) that is kinda
+  // like machine-as-action, but where the success response calls `next`)
+  // This would be so that  machine defs can be registered as middleware?
+  // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
   if (!_.isArray(middleware)) {
     middleware = [middleware];
   }
 
   if (!_.all(middleware, _.isFunction)) {
-    throw new Error('Attempted to register middleware for `' + actions + '` but one or more of the provided middleware was not a function.');
+    throw new Error('Attempted to register action middleware(s) (aka policies) for `' + actionsGlobKey + '` but one or more provided action middlewares (policies) was not a function.');
   }
 
-  // Get or create the array for this middleware key.
-  var middlewareForKey = this._actionMiddleware[actions] || [];
+  // Get or create the array for this glob key.
+  var existingActionMiddlewareRegisteredForGlobKey = sails._actionMiddleware[actionsGlobKey] || [];
 
-  // Add this middleware to the array.
-  middlewareForKey = middlewareForKey.concat(middleware);
+  // Add these middlewares to the array.
+  existingActionMiddlewareRegisteredForGlobKey = existingActionMiddlewareRegisteredForGlobKey.concat(middleware);
 
-  // Assign the array back to the dictionary.
-  this._actionMiddleware[actions] = middlewareForKey;
+  // Assign the array back to our `_actionMiddleware` dictionary.
+  sails._actionMiddleware[actionsGlobKey] = existingActionMiddlewareRegisteredForGlobKey;
 
 };

--- a/lib/app/register-action.js
+++ b/lib/app/register-action.js
@@ -1,4 +1,11 @@
 /**
+ * Module dependencies
+ */
+
+var helpRegisterAction = require('./private/controller/help-register-action');
+
+
+/**
  * Sails.prototype.registerAction()
  *
  * Register an action with Sails.
@@ -7,15 +14,27 @@
  * This method will throw an error if an action with the specified
  * identity has already been registered.
  *
- * @param {fn/node-machine def} action The action to register
- * @param {string} identity The identity of the action
+ * @param {Function|Dictionary} action  [The action to register]
+ * @param {String} identity [The identity of the action]
  *
+ * @context {SailsApp}
+ *
+ * @throws {Error} If there is a conflicting, previously-registered action
+ *         @property {String} code (==='E_CONFLICT')
+ *         @property {String} identity  [the conflicting identity (always the same as what was passed in)]
+ *
+ * @throws {Error} If the action is invalid
+ *         @property {String} code (==='E_INVALID')
+ *         @property {String} identity  [the action identity (always the same as what was passed in)]
+ *         @property {Error} origError  [the original (raw/underlying) error from `machine-as-action`]
  *
  * @api public
  */
 module.exports = function registerAction(action, identity) {
 
-  // Use the private `registerAction` method, without `force`.
-  this._controller.registerAction(action, identity);
+  var sails = this;
+
+  // Call the private `helpRegisterAction` method, without `force` argument.
+  helpRegisterAction(sails, action, identity);
 
 };

--- a/lib/app/reload-actions.js
+++ b/lib/app/reload-actions.js
@@ -46,7 +46,7 @@ module.exports = function reloadActions(options, cb) {
   }, function doneReloadingActions(err) {
     if (err) {return cb(err);}
     // Reload the controller actions.
-    sails._controller.loadModules(cb);
+    sails._controller.loadActionModules(cb);
   });
 
 


### PR DESCRIPTION
This fixes some assorted bugs that only show themselves when machine-as-action fails w/ an error.  It also adds a missing require, some missing comments, and then refactors the private registerAction function to `helpRegisterAction`, and `loadModules` to `loadActionModules`, for clarity.  And since they're private utilities, it also makes them stateless to match the way our other modern util functions are set up (in particular, removing their dependence on `this` context).   At this point, `sails._controller` should no longer be necessary, and can be removed (I may have missed old references to it though, so that'll need another pass to make sure).