### PR TITLE
[patch] fixes global config bug introduced in 44c6d9b

### DIFF
--- a/lib/app/private/exposeGlobals.js
+++ b/lib/app/private/exposeGlobals.js
@@ -43,7 +43,7 @@ module.exports = function exposeGlobals() {
   // `sails.config.globals._` must be false or an object.
   // (it's probably a function with lots of extra properties, but to future-proof, we'll allow any type of object)
   if (sails.config.globals._ !== false) {
-    if (!_.isObject(sails.config.globals._)) {
+    if (!_.isUndefined(sails.config.globals._) && !_.isObject(sails.config.globals._)) {
       throw flaverr('E_BAD_GLOBAL_CONFIG', new Error('If `sails.config.globals._` is defined, it must be either `false` or an object.'));
     }
     global['_'] = sails.config.globals._;
@@ -51,7 +51,7 @@ module.exports = function exposeGlobals() {
   // `sails.config.globals.async` must be false or an object.
   // (it's probably a plain object aka dictionary, but to future-proof, we'll allow any type of object)
   if (sails.config.globals.async !== false) {
-    if (!_.isObject(sails.config.globals.async)) {
+    if (!_.isUndefined(sails.config.globals.async) && !_.isObject(sails.config.globals.async)) {
       throw flaverr('E_BAD_GLOBAL_CONFIG', new Error('If `sails.config.globals.async` is defined, it must be either `false` or an object.'));
     }
     global['async'] = sails.config.globals.async;
@@ -59,7 +59,7 @@ module.exports = function exposeGlobals() {
 
   // `sails.config.globals.sails` must be a boolean
   if (sails.config.globals.sails !== false) {
-    if (sails.config.globals.sails !== true) {
+    if (!_.isUndefined(sails.config.globals.sails) && sails.config.globals.sails !== true) {
       throw flaverr('E_BAD_GLOBAL_CONFIG', new Error('If `sails.config.globals` is defined, then `sails.config.globals.sails` must be a boolean.'));
     }
     global['sails'] = sails;
@@ -67,7 +67,7 @@ module.exports = function exposeGlobals() {
 
   // `sails.config.globals.models` must be a boolean.
   // `orm` hook takes care of actually globalizing models and adapters (if enabled)
-  if (sails.config.globals.models !== false && sails.config.globals.models !== true) {
+  if (!_.isUndefined(sails.config.globals.models) && sails.config.globals.models !== false && sails.config.globals.models !== true) {
     throw flaverr('E_BAD_GLOBAL_CONFIG', new Error('If `sails.config.globals` is defined, then `sails.config.globals.models` must be a boolean.'));
   }
 


### PR DESCRIPTION
@sgress454, 

Commit `44c6d9b41e1b1ffd38150788085890c8c2cbe286` doesn't allow for attributes in `config/globals.js` to be commented out.  This patch changes `exposeGlobals.js` to make sure each attribute is defined as well as an acceptable data type before throwing an error.