### PR TITLE
[patch] Fixes express 4.x deprecated messages when using send(code, msg)

### DIFF
--- a/lib/hooks/http/get-configured-http-middleware-fns.js
+++ b/lib/hooks/http/get-configured-http-middleware-fns.js
@@ -98,7 +98,7 @@ module.exports = function getBuiltInHttpMiddleware (expressRouterMiddleware, sai
 
           // --•
           // Otherwise, we can go ahead and send a response.
-          return res.send(400, errMsg);
+          return res.status(400).send(errMsg);
         });
       };
 

--- a/lib/hooks/responses/index.js
+++ b/lib/hooks/responses/index.js
@@ -212,9 +212,9 @@ function _mixin_jsonx(req, res) {
     sails.log.debug('***********************************************************************************');
 
     // Send conventional status message if no data was provided
-    // (see http://expressjs.com/api.html#res.send)
+    // (see http://expressjs.com/en/api.html#res.sendStatus)
     if (_.isUndefined(data)) {
-      return res.status(res.statusCode).send();
+      return res.sendStatus(res.statusCode);
     }
     else if (typeof data !== 'object') {
       // (note that this guard includes arrays)

--- a/lib/hooks/responses/index.js
+++ b/lib/hooks/responses/index.js
@@ -212,9 +212,9 @@ function _mixin_jsonx(req, res) {
     sails.log.debug('***********************************************************************************');
 
     // Send conventional status message if no data was provided
-    // (see http://expressjs.com/en/api.html#res.sendStatus)
+    // (see http://expressjs.com/en/api.html#res.send)
     if (_.isUndefined(data)) {
-      return res.sendStatus(res.statusCode);
+      return res.status(res.statusCode).send();
     }
     else if (typeof data !== 'object') {
       // (note that this guard includes arrays)

--- a/lib/hooks/views/res.view.js
+++ b/lib/hooks/views/res.view.js
@@ -130,7 +130,7 @@ module.exports = function _addResViewMethod(req, res, next) {
       err.message = 'No path specified, and no path could be inferred from the request context.';
 
       // Prevent endless recursion:
-      if (req._errorInResView) { return res.send(500); }
+      if (req._errorInResView) { return res.sendStatus(500); }
       req._errorInResView = err;
 
       if (cb_view) { return cb_view(err); }
@@ -290,7 +290,7 @@ module.exports = function _addResViewMethod(req, res, next) {
 
       // Prevent endless recursion:
       if (err && req._errorInResView) {
-        return res.send(500, err);
+        return res.status(500).send(err);
       }
 
 
@@ -357,7 +357,7 @@ module.exports = function _addResViewMethod(req, res, next) {
           else if (process.env.NODE_ENV !== 'production') {
             return res.json(500, err);
           }
-          else {return res.send(500);}
+          else {return res.sendStatus(500);}
           //
           //////////////////////////////////////////////////////////////////
         }

--- a/lib/router/bindDefaultHandlers.js
+++ b/lib/router/bindDefaultHandlers.js
@@ -107,7 +107,7 @@ module.exports = function(sails) {
       // Log a message and try to use `res.send` to respond.
       try {
         sails.log.verbose('A request (%s) did not match any routes, and no `res.notFound` handler is configured.', req.url);
-        res.status(404).send('Not found');
+        res.sendStatus(404);
         return;
       }
 

--- a/lib/router/bindDefaultHandlers.js
+++ b/lib/router/bindDefaultHandlers.js
@@ -43,7 +43,7 @@ module.exports = function(sails) {
         if (err.status === 400 && msgMatches) {
           sails.log.verbose('Bad request: Could not decode the requested URL ('+req.path+')');
           // Note for future: The problematic URL section is: `msgMatches[1]`
-          return res.send(400, 'Bad request: Could not decode requested URL.');
+          return res.status(400).send('Bad request: Could not decode requested URL.');
         }
 
       }
@@ -64,10 +64,10 @@ module.exports = function(sails) {
         sails.log.error('Server Error:');
         sails.log.error(err);
         if (process.env.NODE_ENV === 'production') {
-          return res.send(500);
+          return res.sendStatus(500);
         }
         else {
-          return res.send(500, err);
+          return res.status(500).send(err);
         }
 
       } catch (errorSendingResponse) {

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -215,13 +215,13 @@ Router.prototype.route = function(req, res) {
   sails.log.silly('Handling virtual request :: Running virtual querystring parser...');
   qsParser(req,res, function (err) {
     if (err) {
-      return res.send(400, err && err.stack);
+      return res.status(400).send(err && err.stack);
     }
 
     // Parse cookies
     parseCookies(req, res, function(err){
       if (err) {
-        return res.send(400, err && err.stack);
+        return res.status(400).send(err && err.stack);
       }
 
       // console.log('Ran cookie parser');
@@ -230,7 +230,7 @@ Router.prototype.route = function(req, res) {
       // Load session (if relevant)
       loadSession(req, res, function (err) {
         if (err) {
-          return res.send(400, err && err.stack);
+          return res.status(400).send(err && err.stack);
         }
         // console.log('res is now:\n',res);
         // console.log('\n\n');
@@ -241,7 +241,7 @@ Router.prototype.route = function(req, res) {
         sails.log.silly('Handling virtual request :: Running virtual body parser...');
         bodyParser(req,res, function (err) {
           if (err) {
-            return res.send(400, err && err.stack);
+            return res.status(400).send(err && err.stack);
           }
 
           // Use our private router to route the request
@@ -471,7 +471,7 @@ function bodyParser (req, res, next) {
   // outside of the context of Skipper (i.e. in this case, most commonly from
   // socket.io virtual requests).
   req.file = function fileUploadsNotAvailable(){
-    return res.send(500, 'Streaming file uploads via `req.file()` are only available over HTTP with Skipper.');
+    return res.status(500).send('Streaming file uploads via `req.file()` are only available over HTTP with Skipper.');
   };
 
   var bodyBuffer='';

--- a/lib/router/res.js
+++ b/lib/router/res.js
@@ -276,7 +276,7 @@ module.exports = function _buildResponse (req, _res) {
   // res.json()
   res.json = res.json || function json_shim () {
     var args = normalizeResArgs(arguments);
-    return res.send(args.other, args.statusCode || res.statusCode || 200);
+    return res.status(args.statusCode || res.statusCode || 200).send(args.other);
   };
 
   // res.render()
@@ -287,16 +287,16 @@ module.exports = function _buildResponse (req, _res) {
     }
 
     if (!req._sails) {
-      return  res.send(500, 'Cannot call res.render() - `req._sails` was not attached');
+      return  res.status(500).send('Cannot call res.render() - `req._sails` was not attached');
     }
     if (!req._sails.renderView) {
-      return res.send(500, 'Cannot call res.render() - `req._sails.renderView` was not attached (perhaps `views` hook is not enabled?)');
+      return res.status(500).send('Cannot call res.render() - `req._sails.renderView` was not attached (perhaps `views` hook is not enabled?)');
     }
 
     // TODO:
     // Instead of this shim, turn `sails.renderView` into something like
     // `sails.hooks.views.render()`, and then call it.
-    return res.send(501,'Not implemented in core yet');
+    return res.status(501).send('Not implemented in core yet');
   };
 
   // res.redirect()
@@ -309,7 +309,7 @@ module.exports = function _buildResponse (req, _res) {
     res.set('Location',address);
 
     // address = this.get('Location');
-    return res.send(args.statusCode || res.statusCode || 302, 'Redirecting to '+encodeURI(address));
+    return res.status(args.statusCode || res.statusCode || 302).send('Redirecting to '+encodeURI(address));
   };
 
 


### PR DESCRIPTION
Since 4.x, send(code, msg) has been deprecated. The current way of sending a code and a message is res.status(code).send(msg). Also, sending just a status code should use sendStatus

Check http://expressjs.com/en/4x/api.html#res.send, http://expressjs.com/en/4x/api.html#res.status and http://expressjs.com/en/4x/api.html#res.sendStatus for more info