### PR TITLE
[patch] Fix reload actions should reload only activated hooks

### DIFF
--- a/lib/app/reload-actions.js
+++ b/lib/app/reload-actions.js
@@ -32,8 +32,8 @@ module.exports = function reloadActions(options, cb) {
   // Default `hooksToSkip` to an empty array.
   var hooksToSkip = options.hooksToSkip || [];
 
-  // The list of hooks we want to reload is the list of all hooks minus the hooks to skip.
-  var hooksToReload = _.difference(_.keys(sails.hooks), hooksToSkip);
+  // The list of activated hooks we want to reload is the list of all hooks minus the hooks to skip.
+  var hooksToReload = _.difference(_.filter(_.keys(sails.hooks), function(hook) { return sails.hooks[hook]; }), hooksToSkip);
 
   // Clear the actions dictionary.
   sails._actions = {};


### PR DESCRIPTION
_.keys(sails.hooks) return all hooks activated or not
_.filter(_.keys(sails.hooks), function(hook) { return sails.hooks[hook]; }) remove false values