### PR TITLE
[patch] Make sails.emit 100% EventEmitter.emit compatible

### DIFF
--- a/lib/app/private/after.js
+++ b/lib/app/private/after.js
@@ -21,7 +21,7 @@ var async = require('async');
  *
  * This is a lot like jQuery's `$(document).ready()`.
  *
- * @param  {EventEmitter} emitter
+ * @param  {EventEmitter} emitter The Sails application instance
  */
 
 module.exports = function mixinAfter(emitter) {
@@ -36,18 +36,23 @@ module.exports = function mixinAfter(emitter) {
   emitter.warmEvents = {};
 
 
+  var _emit = emitter.emit;
   /**
    * emitter.emit()
    *
-   * Override `EventEmitter.prototype.emit`.
+   * Synchronously calls each of the listeners registered for the event named eventName, in the order they were registered, passing the supplied arguments to each.
+   *
+   * Override `EventEmitter.prototype.emit` to keep track of all the events that have occurred once.
    * (Required to support `emitter.after()`)
+   *
+   * @param {String} eventName name of the event
+   * @return {boolean} Returns true if the event had listeners, false otherwise.
+   * @see https://nodejs.org/api/events.html#events_emitter_emit_eventname_args
    */
-
-  var _emit = emitter.emit;
-  emitter.emit = function(evName) {
+  emitter.emit = function(eventName) {
     var args = Array.prototype.slice.call(arguments, 0);
-    emitter.warmEvents[evName] = true;
-    _emit.apply(emitter, args);
+    emitter.warmEvents[eventName] = true;
+    return _emit.apply(emitter, args);
   };
 
 


### PR DESCRIPTION
According to https://nodejs.org/api/events.html#events_emitter_emit_eventname_args, emit should return a boolean: true if the event had listeners, false otherwise.
Also clarified some docs.