### PR TITLE
[Fixes #3812] Istanbul 0.4.1 is using a module which uses the deprecated minimatch@…

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "connect-redis": "3.1.0",
     "expect.js": "0.3.1",
     "fs-extra": "0.30.0",
-    "istanbul": "0.4.1",
+    "istanbul": "0.4.5",
     "machinepack-fs": "^8.0.2",
     "mocha": "3.0.2",
     "nunjucks": "2.5.2",


### PR DESCRIPTION
Istanbul 0.4.1 is using a module which uses the deprecated minimatch@2.0.10. Update to 0.4.5 fixed it.

<!-- 
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact
sgress454@treeline.io

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!  
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example: 
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->

