### PR TITLE
[patch] Module loader only js code and config files (and derivatives/dialects)

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -365,11 +365,11 @@ module.exports = function(sails) {
       }
 
       async.auto({
-        // Load apps from the "api/hooks" folder
+        // Load user hooks from the "api/hooks" folder
         hooksFolder: function(cb) {
           includeAll.optional({
             dirname: sails.config.paths.hooks,
-            filter: /^([^.]+)\..+$/,
+            filter: new RegExp('^([^.]+)\\.(' + codeExt + ')$'),
 
             // Hooks should be defined as either single files as a function
             // OR (better yet) a subfolder with an index.js file

--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -8,6 +8,8 @@ module.exports = function(sails) {
   var async = require('async');
   var _ = require('@sailshq/lodash');
   var includeAll = require('include-all');
+  var codeExt = require('common-js-file-extensions').code.join('|');
+  var configExt = require('common-js-file-extensions').config.join('|') + '|' + codeExt;
 
 
 
@@ -132,7 +134,7 @@ module.exports = function(sails) {
             dirname   : sails.config.paths.config,
             exclude   : ['locales', /local\..+/],
             excludeDirs: /(locales|env)$/,
-            filter    : /^([^.]+)\.(?:(?!md|txt).)+$/,
+            filter    : new RegExp('^([^.]+)\\.(' + configExt + ')$'),
             flatten   : true,
             keepDirectoryPath: true,
             identity  : false
@@ -142,7 +144,7 @@ module.exports = function(sails) {
         'config/local' : function loadLocalOverrideFile (cb) {
           includeAll.aggregate({
             dirname   : sails.config.paths.config,
-            filter    : /local\..+$/,
+            filter    : new RegExp('^local\\.(' + configExt + ')$'),
             identity  : false
           }, cb);
         },
@@ -155,7 +157,7 @@ module.exports = function(sails) {
           var env = sails.config.environment || async_data['config/local'].environment || 'development';
           includeAll.aggregate({
             dirname   : path.resolve( sails.config.paths.config, 'env', env ),
-            filter    : /^([^.]+)\.(?:(?!md|txt).)+$/,
+            filter    : new RegExp('^([^.]+)\\.(' + configExt + ')$'),
             optional  : true,
             flatten   : true,
             keepDirectoryPath: true,
@@ -171,7 +173,7 @@ module.exports = function(sails) {
           var env = sails.config.environment || async_data['config/local'].environment || 'development';
           includeAll.aggregate({
             dirname   : path.resolve( sails.config.paths.config, 'env' ),
-            filter    : new RegExp('^' + _.escapeRegExp(env) + '\\..+$'),
+            filter    : new RegExp('^' + _.escapeRegExp(env) + '\\.(' + configExt + ')$'),
             optional  : true,
             flatten   : true,
             keepDirectoryPath: true,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "captains-log": "1.0.0",
     "chalk": "1.1.3",
     "commander": "2.8.1",
+    "common-js-file-extensions": "1.0.2",
     "compression": "1.6.2",
     "connect": "3.4.1",
     "cookie": "0.1.2",


### PR DESCRIPTION
<!-- 
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact
sgress454@treeline.io

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!  
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example: 
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->
Module loader only js code and config files (and derivatives/dialects)
- Adds common-js-file-extensions module, with code and configuration extensions 
used in different JavaScript dialects and derivatives.
- Reads only config files when reading config files from 'config/env/*' The 
previous implementation was reading any kind of file extension.
- Reads only config files when reading config files from 'config/env/**'. The 
previous implementation was reading any kind of file extension.
- Reads only config files when reading config files from 'config/local'. The
previous implementation was reading any kind of file extension, it was requiring
other files found in our projects, such as local.sample files.
- Reads only config files when reading config files from 'config/*'. The 
previous implementation was reading any kind of file extension, such as .md 
files
- Make hooks load only js (and friends) code files