### PR TITLE
[patch] Fix lift timeout error wording in http hook

### DIFF
--- a/lib/hooks/http/start.js
+++ b/lib/hooks/http/start.js
@@ -67,7 +67,7 @@ module.exports = function (sails) {
               sails.log.error('(received error: ' + err.code + ')');
             }
           } else {
-            sails.log.error('Server is taking a while to start up (it\'s been 4 seconds).');
+            sails.log.error('Server is taking a while to start up (it\'s been ' + (liftTimeout / 1000) + ' seconds).');
           }
 
           sails.log.error();


### PR DESCRIPTION
<!--
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact us directly
at http://sailsjs.com/contact.

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example:
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->
When server starts longer than configurable `liftTimeout`, sails exists with this error from http hook:
>Server is taking a while to start up (it\'s been 4 seconds).'

"4 seconds" in this error message was hardcoded. This fix displays real listTimeout value in the error.