### PR TITLE
Add shortcuts for common automigration settings.

### DIFF
--- a/lib/app/configuration/load.js
+++ b/lib/app/configuration/load.js
@@ -56,28 +56,50 @@ module.exports = function(sails) {
         // (that way, we don't have to rely on duplicate code in app.js and in bin/sails-lift.js)
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-        // Map Sails options from overrides
-        overrides = _.merge(overrides, {
 
-          // `--verbose` command-line argument
-          // `--silly` command-line argument
-          // `--silent` command-line argument
-          log: overrides.verbose ? {
-            level: 'verbose'
-          } : overrides.silly ? {
-            level: 'silly'
-          } : overrides.silent ? {
-            level: 'silent'
-          } : undefined,
+        // Map Sails options from overrides, handling a few special "shortcuts"
+        // (i.e. allowing for CLI arguments like `--verbose`, instead of `--log.level=verbose`)
+        try {
+          overrides = _.merge(overrides, {
 
-          // `--port=?` command-line argument
-          port: overrides.port || undefined,
+            // `--verbose` command-line shortcut
+            // `--silly` command-line shortcut
+            // `--silent` command-line shortcut
+            log: overrides.verbose ? {
+              level: 'verbose'
+            } : overrides.silly ? {
+              level: 'silly'
+            } : overrides.silent ? {
+              level: 'silent'
+            } : undefined,
 
-          // `--prod` command-line argument
-          environment: overrides.prod ? 'production' : (overrides.dev ? 'development' : undefined)
+            // `--port=?` command-line shortcut
+            port: overrides.port || undefined,
 
-        });
+            // `--safe` command-line shortcut
+            // `--alter` command-line shortcut
+            // `--drop` command-line shortcut
+            models: (function(){
+              if (overrides.safe) {
+                return { migrate: 'safe' };
+              }
+              else if (overrides.drop) {
+                return { migrate: 'drop' };
+              }
+              else if (overrides.alter) {
+                return { migrate: 'alter' };
+              }
+              else {
+                return undefined;
+              }
+            })(),
 
+            // `--prod` command-line shortcut
+            environment: overrides.prod ? 'production' : (overrides.dev ? 'development' : undefined)
+
+          });
+
+        } catch (e) { return cb(e); }
 
         // Pass on overrides object
         return cb(undefined, overrides);


### PR DESCRIPTION
This is to make it a little less painful to develop on an app with a bunch of dev data.  It **should (and can) only ever be used in development mode** (in production, it's always forced to `safe` anyway)

e.g. Here's how you can easily lift without waiting for Sails to drop and re-enter all records:

```
sails lift --safe
```

> ^^^This is useful when you know nothing has changed in `api/models/`, and when you know your development data is already valid.  




And e.g. here's how you can easily wipe out all dev data stored in your database(s):

```
sails lift --drop
```



> Currently, you can achieve the same effect by doing `sails lift --models.migrate=safe` and `sails lift --models.migrate=drop`... it's just a little awkward.  I don't know about you guys, but frankly it takes me like 30 seconds to remember how to type that like every time I do it, no matter how many times I do it.  These command-line argument shortcuts are really just here as a convenience to make that a bit better.