### PR TITLE
[patch] Filter out the --inspect flag when launching grunt.

### DIFF
--- a/lib/hooks/grunt/index.js
+++ b/lib/hooks/grunt/index.js
@@ -135,7 +135,7 @@ module.exports = function(sails) {
           // Pass all current node process arguments to the child process,
           // except the debug-related arguments, see issue #2670
           execArgv: process.execArgv.slice(0).filter(function(param) {
-            return !(new RegExp('--debug(-brk=[0-9]+)?').test(param));
+            return !(new RegExp('(--debug|--inspect)(-brk=[0-9]+)?').test(param));
           })
         }
       );


### PR DESCRIPTION
In Node v6.3 the V8 Inspector was added to replace the Node remote debugger added in Node v4. To enable the V8 Inspector you need to pass the `--inspect` (or `--inspect-brk`) flag when launching your node application.

When using the grunt hook a new process is forked to run grunt.
The arguments passed in when lifting sails is passed on to the new fork which included the debug flags. In issue https://github.com/balderdashy/sails/issues/2670 a filter was added to remove the debug flags when spawning the fork however this filter only knew about the Node v4 flags and not the new V8 Inspector flags. The result is that if you try to use the V8 Inspector and the Grunt hook
the spawned process will launch with V8 Inspector and cause a port conflict on your app which also tries to start the V8 Inspector.

To fix that this change updates the filter to also filter out the `--inspect` flags when spawning a grunt process.
