### PR TITLE
[patch] Reducing the log severity of redis disconnect and reconnect to verbose

### DIFF
--- a/lib/hooks/session/index.js
+++ b/lib/hooks/session/index.js
@@ -317,14 +317,14 @@ module.exports = function(app) {
                   if (_.isFunction(app.config.session.onRedisDisconnect)) {
                     app.config.session.onRedisDisconnect();
                   }
-                  app.log.error('Redis session server went offline...');
+                  app.log.verbose('Redis session server went offline...');
                   // If a disconnected client comes back, say something and run any custom logic
                   // that was provided for this occasion.
                   err.connection.once('ready', function() {
                     if (_.isFunction(app.config.session.onRedisDisconnect)) {
                       app.config.session.onRedisReconnect();
                     }
-                    app.log.error('Redis session server came back online...');
+                    app.log.verbose('Redis session server came back online...');
                   });
                 }
               }

--- a/lib/hooks/session/index.js
+++ b/lib/hooks/session/index.js
@@ -318,10 +318,10 @@ module.exports = function(app) {
                     app.config.session.onRedisDisconnect();
                   }
                   app.log.verbose('Redis session server went offline...');
-                  // If a disconnected client comes back, say something and run any custom logic
+                  // If a disableconnected client comes back, say something and run any custom logic
                   // that was provided for this occasion.
                   err.connection.once('ready', function() {
-                    if (_.isFunction(app.config.session.onRedisDisconnect)) {
+                    if (_.isFunction(app.config.session.onRedisReconnect)) {
                       app.config.session.onRedisReconnect();
                     }
                     app.log.verbose('Redis session server came back online...');

--- a/lib/hooks/session/index.js
+++ b/lib/hooks/session/index.js
@@ -318,7 +318,7 @@ module.exports = function(app) {
                     app.config.session.onRedisDisconnect();
                   }
                   app.log.verbose('Redis session server went offline...');
-                  // If a disableconnected client comes back, say something and run any custom logic
+                  // If a disconnected client comes back, say something and run any custom logic
                   // that was provided for this occasion.
                   err.connection.once('ready', function() {
                     if (_.isFunction(app.config.session.onRedisReconnect)) {


### PR DESCRIPTION
<!--
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact us directly
at http://sailsjs.com/contact.

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example:
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->

Given the verbose log level of the Redis error on L312, I'm assuming the errors on L320 and L327 were meant to be logged with a verbose log level as well.  We're on Heroku and are getting hundreds of these errors which is flooding our Sentry logging as the Redis connections timeout every 300 seconds.

Another potential implementation would be to move the errors to an else block after the check for `onRedisDisconnect` and `onRedisReconnect` functions if the intent is for the onRedis... to provide custom overriding rather than supplemental logic.

Also fixing what I suspect is a typo on L324 where currently the logic checks for an `onRedisDisconnect` definition but then fires `onRedisReconnect`.
