### PR TITLE
[fixes #4286] Bug Model.update modifies queryOptions

### DIFF
--- a/lib/hooks/blueprints/actions/update.js
+++ b/lib/hooks/blueprints/actions/update.js
@@ -55,7 +55,7 @@ module.exports = function updateOneRecord (req, res) {
 
     if (!matchingRecord) { return res.notFound(); }
 
-    Model.update(_.cloneDeep(criteria), queryOptions.valuesToSet).meta(queryOptions.meta).exec(function updated(err, records) {
+    Model.update(_.cloneDeep(criteria), _.cloneDeep(queryOptions.valuesToSet)).meta(queryOptions.meta).exec(function updated(err, records) {
 
       // Differentiate between waterline-originated validation errors
       // and serious underlying issues. Respond with badRequest if a


### PR DESCRIPTION
<!--
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact us directly
at http://sailsjs.com/contact.

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example:
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->
# Info

When I tried to update a model **item**

```
{
        description: {
            type: 'string',
            required: true
        },
        tags: {
            collection: 'tag',
            via: 'items'
        }
}
```

model **tag** is

```
{
    name: {
        type: 'string',
        required: true,
        unique: true
    },
    items: {
        collection: 'item',
        via: 'tags'
    }
}
```

with the following query

`{ description: 'TEST #1', tags: [ 1, 3 ], id: '1' }`

and listening on the resourceful socket for the update pub/sub 

what I expected

`{ description: 'TEST #1', tags: [ 1, 3 ], id: '1' }`

what I got

`{ description: 'TEST #1', id: '1' }`

This commit fixes the problem
