### PR TITLE
[patch] Fix the event is triggered before a listener is added

### DIFF
--- a/lib/app/private/loadHooks.js
+++ b/lib/app/private/loadHooks.js
@@ -234,11 +234,12 @@ module.exports = function(sails) {
           return;
         }
 
-        sails.log.verbose(id, 'hook loaded successfully. ('+(Date.now() - timestampBeforeLoad)+'ms)');
-        sails.emit('hook:' + id + ':loaded');
-
         // Defer a tick to allow other stuff to happen
-        process.nextTick(function(){ cb(); });
+        process.nextTick(function(){
+          sails.log.verbose(id, 'hook loaded successfully. ('+(Date.now() - timestampBeforeLoad)+'ms)');
+          sails.emit('hook:' + id + ':loaded');
+          cb();
+        });
       });
     }//ƒ
 


### PR DESCRIPTION
[silly log](https://gist.github.com/zyvas/da9d1678b692ffa80bf46d10f4c05d17#file-sails-log-L55)

initialize in method flood

```javascript
initialize: function (done) {
  sails.log.info('Initializing custom hook (`flood`)');
  sails.on('hook:responses:loaded', () => {
    return done();
  });
}
```

 the listener is not called what is registers after responses hook has been loaded successfully.
