### PR TITLE
[proposal] Prevent moduleloader from loading sourcemap files

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -303,7 +303,7 @@ module.exports = function(sails) {
       // Get the main model files
       includeAll.optional({
         dirname   : sails.config.paths.models,
-        filter    : /^(.+)\.(?:(?!md|txt).)+$/,
+        filter    : /^(.+)\.(?:(?!md|txt|map).)+$/,
         replaceExpr : /^.*\//,
         flatten: true
       }, function(err, models) {
@@ -338,7 +338,7 @@ module.exports = function(sails) {
     loadServices: function (cb) {
       includeAll.optional({
         dirname     : sails.config.paths.services,
-        filter      : /^(.+)\.(?:(?!md|txt).)+$/,
+        filter      : /^(.+)\.(?:(?!md|txt|map).)+$/,
         depth     : 1,
         caseSensitive : true
       }, bindToSails(cb));
@@ -353,7 +353,7 @@ module.exports = function(sails) {
     statViews: function (cb) {
       includeAll.optional({
         dirname: sails.config.paths.views,
-        filter: /^(.+)\.(?:(?!md|txt).)+$/,
+        filter: /^(.+)\.(?:(?!md|txt|map).)+$/,
         replaceExpr: null,
         dontLoad: true
       }, cb);
@@ -368,7 +368,7 @@ module.exports = function(sails) {
     loadPolicies: function (cb) {
       includeAll.optional({
         dirname: sails.config.paths.policies,
-        filter: /^(.+)\.(?:(?!md|txt).)+$/,
+        filter: /^(.+)\.(?:(?!md|txt|map).)+$/,
         replaceExpr: null,
         flatten: true,
         keepDirectoryPath: true
@@ -574,7 +574,7 @@ module.exports = function(sails) {
     loadBlueprints: function (cb) {
       includeAll.optional({
         dirname: sails.config.paths.blueprints,
-        filter: /^(.+)\.(?:(?!md|txt).)+$/,
+        filter: /^(.+)\.(?:(?!md|txt|map).)+$/,
         useGlobalIdForKeyName: true
       }, cb);
     },
@@ -588,7 +588,7 @@ module.exports = function(sails) {
     loadResponses: function (cb) {
       includeAll.optional({
         dirname: sails.config.paths.responses,
-        filter: /^(.+)\.(?:(?!md|txt).)+$/,
+        filter: /^(.+)\.(?:(?!md|txt|map).)+$/,
         useGlobalIdForKeyName: true
       }, bindToSails(cb));
     },


### PR DESCRIPTION
We are unable to upgrade to sails V1 because we compile our api files before lifting sails. Since sails v1 *every* files are loaded as script files, even sourcemaps. The problem: we needs sourcemaps to enable debugging in original files.
