### PR TITLE
[proposal] Add support for Vuejs templates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@ Feature                                          | Proposal                     
  :---------------------------------------------- | :------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------
  Allow select/omit clauses when populating a singular association | https://trello.com/c/yM9WPxzr/107-waterline-fs2q-tolerate-a-subcriteria-being-provided-to-populate-for-a-singular-associations-but-only-if-it-exclusively-contains | Don't throw an error if these clauses are included in a `populate` for a singular association (but still error if actual "where" criteria are used)
  Generate `test/` folder in new Sails apps       | [#2499](https://github.com/balderdashy/sails/pull/2499#issuecomment-171556544)        | Generate a generic setup for mocha tests in all new Sails apps.  Originally suggested by [@jedd-ahyoung](https://github.com/jedd-ahyoung).
+ Add support for Vuejs templates | | Since consolidate doesn't support Vuejs templates, I think it should be useful for a lot of web developers to be able to use this templates as it makes it much easier to work on the client-side while using Sails global variables inside. The express-vue module can solve that, but it uses a .renderVue() function which is not native .view() Sail's function and so we can't use Sail's globale variables inside Vuejs templates.
 
 
 


### PR DESCRIPTION
<!--
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact us directly
at http://sailsjs.com/contact.

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example:
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->
Hello!
Since consolidate doesn't support Vuejs templates, I think it should be useful for a lot of web developers to be able to use this templates as it makes it much easier to work on the client-side while using Sails global variables inside. The express-vue module can solve that, but it uses a .renderVue() function which is not native .view() Sail's function and so we can't use Sail's globale variables inside Vuejs templates.
