### PR TITLE
[patch] removed erroneous auto publishUpdate for model to model associations

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -675,20 +675,11 @@ module.exports = function(sails) {
             if (association.type === 'model' && association.alias && previous[association.alias]) {
               ReferencedModel = sails.models[association.model];
               // Get the inverse association definition, if any
-              reverseAssociation = _.find(ReferencedModel.associations, {collection: this.identity}) || _.find(ReferencedModel.associations, {model: this.identity});
+              reverseAssociation = _.find(ReferencedModel.associations, {collection: this.identity});
 
               if (reverseAssociation) {
-                // If it's a to-one, publish a simple update alert
                 var referencedModelId = _.isObject(previous[association.alias]) ? previous[association.alias][ReferencedModel.primaryKey] : previous[association.alias];
-                if (reverseAssociation.type === 'model') {
-                  var pubData = {};
-                  pubData[reverseAssociation.alias] = null;
-                  ReferencedModel._publishUpdate(referencedModelId, pubData, req, {noReverse:true});
-                }
-                // If it's a to-many, publish a "removed" alert
-                else {
-                  ReferencedModel._publishRemove(referencedModelId, reverseAssociation.alias, id, req, {noReverse:true});
-                }
+                ReferencedModel._publishRemove(referencedModelId, reverseAssociation.alias, id, req, {noReverse:true});
               }
             }
 


### PR DESCRIPTION
this auto update makes no sense. consider this example:
```js
// Model Foo
module.exports = {
    attributes: {
        parent: { model: "foo" }
    }
}
```

now if you have three instances `Foo({ id: 1, parent: null })` and `Foo({ id: 2, parent: 1 })` and `Foo({ id: 3, parent: 2 })`. If we call `io.socket.delete('/foo/3')` sails will publish an update:
```json
{
    "verb": "updated",
    "id": 2,
    "data": {
        "parent": null
    }
}
```
