### PR TITLE
Fixes winston v3.x logger compatibility issue

### DIFF
--- a/lib/app/lift.js
+++ b/lib/app/lift.js
@@ -107,7 +107,7 @@ module.exports = function lift(configOverride, done) {
       }
       sails.log('Port        : ' + sails.config.port); // 12 - 4 = 8 spaces
       sails.log.verbose('NODE_ENV  : ' + (process.env.NODE_ENV||chalk.gray('(not set)'))); // 12 - 8 - 2 = 2 spaces
-      sails.log.silly();
+      sails.log.silly('');
       sails.log.silly('Version Info:');
       sails.log.silly('node        : ' + (process.version));
       sails.log.silly('engine (v8) : ' + (process.versions.v8));


### PR DESCRIPTION
Using `winston` as a custom logger, calling `log.silly()` without parameters would cause a `TypeError` exception such as the following one. Using an empty string solves the problem.

```
node_modules/winston/lib/winston/logger.js:130
      level[LEVEL] = level.level;
                   ^

TypeError: Cannot create property 'Symbol(level)' on string 'silly'
  at DerivedLogger.log (node_modules/winston/lib/winston/logger.js:130:20)
  at Function.(anonymous function) (node_modules/winston/lib/winston/create-logger.js:62:21)
  at Function._writeLogToConsole [as silly] (node_modules/captains-log/lib/write.js:47:20)
  at whenSailsIsReady (node_modules/sails/lib/app/lift.js:110:17)
  at node_modules/sails/node_modules/async/dist/async.js:3861:9
  at node_modules/sails/node_modules/async/dist/async.js:421:16
  at replenish (node_modules/sails/node_modules/async/dist/async.js:941:25)
  at iterateeCallback (node_modules/sails/node_modules/async/dist/async.js:931:17)
  at node_modules/sails/node_modules/async/dist/async.js:906:16
  at node_modules/sails/node_modules/async/dist/async.js:3858:13
  at node_modules/sails/lib/app/private/initialize.js:91:14
  at node_modules/sails/node_modules/async/dist/async.js:421:16
  at iteratorCallback (node_modules/sails/node_modules/async/dist/async.js:998:13)
  at node_modules/sails/node_modules/async/dist/async.js:906:16
  at expressListening (node_modules/sails/lib/hooks/http/start.js:169:14)
  at node_modules/sails/node_modules/async/dist/async.js:421:16
  at processQueue (node_modules/sails/node_modules/async/dist/async.js:1565:20)
  at taskComplete (node_modules/sails/node_modules/async/dist/async.js:1588:9)
  at node_modules/sails/node_modules/async/dist/async.js:1612:17
  at node_modules/sails/node_modules/async/dist/async.js:906:16
  at async.auto.verify (node_modules/sails/lib/hooks/http/start.js:160:9)
  at runTask (node_modules/sails/node_modules/async/dist/async.js:1619:13)
  at node_modules/sails/node_modules/async/dist/async.js:1559:13
  at processQueue (node_modules/sails/node_modules/async/dist/async.js:1569:13)
  at taskComplete (node_modules/sails/node_modules/async/dist/async.js:1588:9)
  at Server.<anonymous> (node_modules/sails/node_modules/async/dist/async.js:1612:17)
  at Server.<anonymous> (node_modules/sails/node_modules/async/dist/async.js:906:16)
  at Server.g (events.js:292:16)
  at emitNone (events.js:91:20)
  at Server.emit (events.js:185:7)
  at emitListeningNT (net.js:1284:10)
  at _combinedTickCallback (internal/process/next_tick.js:77:11)
  at process._tickCallback (internal/process/next_tick.js:104:9)
```

<!--
======================================================
HELLO, and welcome to the (experimental) Sailsbot
pr-submission system.  If you encounter any
problems with this system, please contact us directly
at http://sailsjs.com/contact.

IMPORTANT - Read Carefully (Sailsbot will know if you don't)!
======================================================

Before submitting a pull request for a new feature request, pretty-please read the Sails contribution guide section on proposing features and enhancements: http://bit.ly/sails-feature-guide.
Before submitting a pull request with code, please read the section on contributing code: http://bit.ly/sails-code-guide.

They're a little long, but that's because we're serious about keeping Sails lean, stable and secure.

If after all that, you're still ready to make a pull request, make sure that your PR title starts with one of the following:

[proposal]
[patch]
[implements #<another PR number>]
[fixes #<an issue number>]

For example:
[proposal] Add a Kraken to the `sails lift` sailboat image
[implements #123] Adds Kraken to sailboat
[patch] Fix the shading on the Kraken's tentacles
[fixes #423] Removes pesky "throw new Error('yolo');" added when Kraken is displayed

If you don't use one of those prefixes, Sailsbot will bring the hammer down.  You have been warned!

Ok, that's all.  Please put the description of your pull request below (after the arrow).
-->

