### PR TITLE
[patch] Replace uid-safe to nanoid

### DIFF
--- a/lib/hooks/session/index.js
+++ b/lib/hooks/session/index.js
@@ -9,7 +9,7 @@ var flaverr = require('flaverr');
 var Redis = require('machinepack-redis');
 
 // (this dependency is just for creating new cookies)
-var uid = require('uid-safe');
+var nanoid = require('nanoid');
 
 // (these two dependencies are only here for sails.session.parseSessionIdFromCookie(),
 //  which is only here to enable socket lifecycle callbacks)
@@ -480,7 +480,7 @@ module.exports = function(app) {
 
     generateNewSidCookie: function (){
 
-      var sid = uid.sync(24);
+      var sid = nanoid(32);
       var signedSid = 's:' + signCookie(sid, app.config.session.secret);
       var cookie = stringifyCookie(app.config.session.name, signedSid, {});
       return cookie;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "merge-defaults": "0.2.1",
     "merge-dictionaries": "1.0.0",
     "minimist": "0.0.10",
+    "nanoid": "^1.2.3",
     "parley": "^3.3.4",
     "parseurl": "1.3.2",
     "path-to-regexp": "1.5.3",
@@ -65,7 +66,6 @@
     "serve-static": "1.13.1",
     "skipper": "^0.9.0-0",
     "sort-route-addresses": "^0.0.1",
-    "uid-safe": "2.1.5",
     "vary": "1.1.2",
     "whelk": "^6.0.1"
   },


### PR DESCRIPTION
`uid-safe` is a random string ID generator. Sails uses it in session ID generator.

This PR replaces `uid-safe` to [`nanoid`](https://github.com/ai/nanoid)

> Why do we need it?

1. Nano ID is [10% faster](https://github.com/ai/nanoid#benchmark)
2. Nano ID has no dependencies compare to 1 dependency of `uid-safe`
3. Nano ID has automatic tests that [distribution is flat](https://github.com/ai/nanoid/blob/master/test/index.test.js#L28-L52) and everything is secure
4. We have the cool logo 😄 and [good documentation](https://github.com/ai/nanoid/blob/master/README.md). Even a special website to calculate [ID length](https://zelark.github.io/nano-id-cc/).

> Is it a big project or some unknown project that we should not care about

Nano ID is not just new unknown project. It has [1M+ downloads per month](https://npm-stat.com/charts.html?package=nanoid).

Docs was translated to Chinese. It has ported to 13 langauges](https://github.com/ai/nanoid#other-programming-languages).

> Can we trust this project?

Nano ID was created by the author of PostCSS and Autoprefixer. The community can trust me 😄.

Nano ID right now is used by many users. For instance, it is used by [Zeit’s Next.js](https://github.com/zeit/next.js/commit/918e0a6e3230ef0e33a5698cd09aa274cb0a1fec).

> Is it safe?

Yeap, Nano ID uses hardware randome generator (same as `uid-safe`). We really care about security, we have automatic tests for security. For instance, we tests flat distribution (it guarantees unpredictability) [in Node.js](https://github.com/ai/nanoid/blob/master/test/index.test.js#L28-L52) and [browsers](https://github.com/ai/nanoid/blob/master/test/demo/index.js).

@mikermcneil to be honest, it is not a big PR which dramatcally change everything. It will just a very little increase perfomance and remove one dependency. But in other hand, it is small cute change without any risks. During PostCSS maintaince, I very like this type of PR 😎