### PR TITLE
(0.12.x) Update captains-log and rc dependencies to fix error running tests with Mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "anchor": "~0.10.5",
     "async": "1.5.0",
-    "captains-log": "1.0.0",
+    "captains-log": "^2.0.2",
     "chalk": "1.1.3",
     "commander": "2.9.0",
     "compression": "1.6.2",
@@ -70,7 +70,7 @@
     "path-to-regexp": "1.5.3",
     "pluralize": "1.2.1",
     "prompt": "0.2.14",
-    "rc": "1.0.1",
+    "rc": "^1.2.8",
     "reportback": "~0.1.9",
     "rttc": "9.3.3",
     "sails-disk": "~0.10.9",


### PR DESCRIPTION
  - Fixes `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type boolean` error at `Object.exports.json (node_modules/captains-log/node_modules/rc/lib/utils.js:20:24)`

![Error message](https://user-images.githubusercontent.com/538730/57093283-13f17000-6cd3-11e9-8ea5-1d4f155d1b51.png)