### PR TITLE
[fixes #6541]. omit prefix to avoid doubling up when key gets set

### DIFF
--- a/lib/hooks/session/index.js
+++ b/lib/hooks/session/index.js
@@ -302,7 +302,7 @@ module.exports = function(app) {
             // Create a Redis connection manager.
             Redis.createManager({
               connectionString: url,
-              meta: _.omit(app.config.session, ['host', 'port', 'pass', 'db', 'url', 'adapter']),
+              meta: _.omit(app.config.session, ['host', 'port', 'pass', 'db', 'url', 'adapter', 'prefix']),
               // Handle failures on the connection.
               onUnexpectedFailure: function(err) {
                 // If Sails is already on the way out, ignore the Redis issue.


### PR DESCRIPTION
Fix for issue: https://github.com/balderdashy/sails/issues/6541.

The prefix was being included twice in the redis store.