### PR TITLE
Skip CSRF validation when no session cookie is present

### DIFF
--- a/lib/hooks/security/csrf/index.js
+++ b/lib/hooks/security/csrf/index.js
@@ -102,6 +102,11 @@ module.exports = function(sails) {
           }
         }
 
+        // Continue when no session cookie is present. CSRF protection is only relevant with cookie-based auth.
+        if (!_.has(req, ['signedCookies', 'sails.sid'])) {
+          return next();
+        }
+
         // Handle session being disabled.
         if (!req.session) {
           // For GET, HEAD and OPTIONS requests, continue on.  These aren't covered by CSRF anyway.


### PR DESCRIPTION
## What / Why
Sails currently enforces CSRF protection based on routes (and methods) alone.  This makes it difficult (or impossible) to simultaneously **a)** enforce CSRF on a route when accessed through a browser client using session cookies while **b)** allowing non-browser clients to access the same route using alternative authentication methods (e.g. bearer tokens).

## Proposed Solution 
I believe we can easily and [securely](https://security.stackexchange.com/a/203179) enable this scenario by dynamically disabling CSRF protection when there is no session cookie on the request body, as proposed in this PR.

*Note: I spent quite some time trying to familiarize myself with the contribution guidelines, but get pretty lost/confused with the move to Trello. If this does not meet standards, please let me know how best to conform and I can fix, submit a formal proposal, or discuss by other means...*