### PR TITLE
[fixes #5630] Update destroy blueprint action so that `afterDestroy` lifecycle callbacks will still run by default

### DIFF
--- a/lib/hooks/blueprints/actions/destroy.js
+++ b/lib/hooks/blueprints/actions/destroy.js
@@ -53,10 +53,11 @@ module.exports = function destroyOneRecord (req, res) {
 
     // (Note: this could be achieved in a single query, but a separate `findOne`
     // is used first to provide a better experience for front-end developers
-    // integrating with the blueprint API out of the box.  If we didn't need
-    // or care about that, we could just use `.meta({fetch: true})` when calling
-    // `.destroy()`.
-    Model.destroy(_.cloneDeep(criteria)).exec(function destroyedRecord (err) {
+    // integrating with the blueprint API out of the box. However, we'll also include
+    // the meta query optons for the purpose of enabling the `afterDestroy`
+    // lifecycle callback (which only runs if `.meta({fetch: true})` is included).
+    Model.destroy(_.cloneDeep(criteria)).meta(queryOptions.meta)
+    .exec(function destroyedRecord (err) {
       if (err) {
         switch (err.name) {
           case 'UsageError': return res.badRequest(formatUsageError(err, req));


### PR DESCRIPTION
Updated the destroy blueprint action so that the meta query options from `parseBlueprintOptions` are passed into the actual call to `.destroy()`, since [`afterDestroy` only runs if `.meta({fetch: true})` is included](https://sailsjs.com/documentation/concepts/models-and-orm/lifecycle-callbacks#?lifecycle-callbacks-on-destroy). This makes the `afterDestroy` lifecycle callback still run by default when using the destroy blueprint action.

Fixes #5630