### PR TITLE
Prevent certain locations from leaking errors in production

### DIFF
--- a/lib/hooks/views/res.view.js
+++ b/lib/hooks/views/res.view.js
@@ -338,7 +338,10 @@ module.exports = function _addResViewMethod(req, res, next) {
 
       // Prevent endless recursion:
       if (err && req._errorInResView) {
-        return res.status(500).send(err);
+        if (process.env.NODE_ENV !== 'production') {
+          return res.status(500).send(err);
+        }
+        else {return res.sendStatus(500);}
       }
 
 

--- a/lib/router/res.js
+++ b/lib/router/res.js
@@ -358,7 +358,7 @@ module.exports = function _buildResponse (req, _res) {
         console.error('res.render() failed: ', e);
       }
 
-      if (process.env.NODE_ENV === 'production') { return res.status(e.statusCode||500).send(e.message); }
+      if (process.env.NODE_ENV !== 'production') { return res.status(e.statusCode||500).send(e.message); }
       else { return res.status(e.statusCode||500).send(); }
     }
 


### PR DESCRIPTION
Stumbled upon these two routines that leaked errors in production while testing. Probably not desired.