### PR TITLE
[PATCH] IN CSRF hook, only lowercase the route path if the route isn't a regex

### DIFF
--- a/lib/hooks/security/csrf/index.js
+++ b/lib/hooks/security/csrf/index.js
@@ -29,7 +29,7 @@ module.exports = function(sails) {
       _.each(sortedRouteAddresses, function(address) {
 
         var routeInfo = detectVerb(address);
-        var path = routeInfo.original.toLowerCase();
+        var path = routeInfo.original;
         var verb = routeInfo.verb.toLowerCase();
         var target = sails.router.explicitRoutes[address];
 
@@ -55,6 +55,7 @@ module.exports = function(sails) {
         if (matches) {
           regex = new RegExp(matches[1]);
         } else {
+          path = path.toLowerCase();
           regex = pathToRegexp(path);
         }
 


### PR DESCRIPTION
See https://github.com/balderdashy/sails/issues/6838