### PR TITLE
chore: Fixed misleading usage information for the CLI

### DIFF
--- a/bin/sails.js
+++ b/bin/sails.js
@@ -42,7 +42,7 @@ program
 
 program
   .unknownOption = NOOP;
-program.usage('[command]');
+program.usage('[command] [options]');
 
 
 // $ sails lift


### PR DESCRIPTION
`Usage: [command] [options]`