### PR TITLE
[proposal] Support camel case for action names

### DIFF
--- a/lib/app/private/controller/README.md
+++ b/lib/app/private/controller/README.md
@@ -77,11 +77,13 @@ sails.registerActionMiddleware(mustBeLoggedIn, ['user.*', 'pet.*'], ['user.publi
 
 ##### `loadActionModules()`
 
-When Sails loads, this method loads all of the files underneath the controllers directory (`api/controllers` by default) and attempts to parse them into actions that can be bound to routes.  File in the controllers directory can either be pascal-cased and ending in "Controller" (e.g. MyController.js), in which case they are expected to be _dictionaries_ of actions, or else kebab-cased and lowercased (e.g. my-action.js) in which case they are expected to contain a single action.  An action may be a function which accepts `req` and `res` as arguments, or a [node-machine](http://node-machine.org) definition which will be parsed by [machine-as-action](https://github.com/treelinehq/machine-as-action).
+When Sails loads, this method loads all of the files underneath the controllers directory (`api/controllers` by default) and attempts to parse them into actions that can be bound to routes.  File in the controllers directory can either be pascal-cased and ending in "Controller" (e.g. MyController.js), in which case they are expected to be _dictionaries_ of actions, or else (kebab-cased and lowercased (e.g. my-action.js by default) ) in which case they are expected to contain a single action.  An action may be a function which accepts `req` and `res` as arguments, or a [node-machine](http://node-machine.org) definition which will be parsed by [machine-as-action](https://github.com/treelinehq/machine-as-action).
 
 After actions are loaded from disk, any actions specified under the `sails.config.controllers.moduleDefinitions` config key are merged on top of those actions.  This allows Sails apps to be constructed dynamically at runtime.
 
 Note that this method is called internally by Sails _after_ hooks have loaded (or in the case of a `Sails.reloadModules` call, after they have _reloaded_).  This ensures that user actions always take precedence over those added by hooks.
+
+You can specify the naming convention of actions with the config located at `sails.config.casings.actions`, options are 'kebab-case' or 'camel-case'
 
 ##### `helpRegisterAction(action, identity, [force])`
 

--- a/lib/app/private/controller/load-action-modules.js
+++ b/lib/app/private/controller/load-action-modules.js
@@ -19,6 +19,8 @@ module.exports = function loadActionModules (sails, cb) {
 
   sails.config.paths = sails.config.paths || {};
   sails.config.paths.controllers = sails.config.paths.controllers || 'api/controllers';
+  sails.config.casing = sails.config.casing || {};
+  sails.config.casing.actions = sails.config.casing.actions || 'kebab-case';
 
   // Keep track of actions loaded from disk, so we can detect conflicts.
   var actionsLoadedFromDisk = {};
@@ -38,9 +40,17 @@ module.exports = function loadActionModules (sails, cb) {
       var garbage = [];
       // Traditional controllers are PascalCased and end with the word "Controller".
       var traditionalRegex = new RegExp('^((?:(?:.*)/)*([0-9A-Z][0-9a-zA-Z_]*))Controller\\..+$');
-      // Actions are kebab-cased.
-      var actionRegex = new RegExp('^((?:(?:.*)/)*([a-z][a-z0-9-]*))\\..+$');
-
+      // Actions are kebab-cased by default 
+      var actionRegex = null;
+      switch(sails.config.casing.actions) {
+        case 'camel-case':
+          actionRegex = new RegExp('^((?:(?:.*)\/)*([a-zA-Z0-9]*))\\..+$');
+          break;
+        case 'kebab-case':
+        default:
+          actionRegex = new RegExp('^((?:(?:.*)/)*([a-z][a-z0-9-]*))\\..+$');
+          break;
+      }
 
       // Loop through all of the files returned from include-all.
       _.each(files, function(moduleDef) {
@@ -131,6 +141,7 @@ module.exports = function loadActionModules (sails, cb) {
         // Attempt to match the file path to the pattern of an action file,
         // and make sure it is either a function OR a dictionary containing
         // a function as its `fn` property.
+        console.log('')
         else if ((match = actionRegex.exec(filePath)) && (_.isFunction(moduleDef) || !_.isUndefined(moduleDef.machine) || !_.isUndefined(moduleDef.friendlyName) || _.isFunction(moduleDef.fn))) {
 
           // The action identity is the same as the module identity

--- a/lib/app/private/controller/load-action-modules.js
+++ b/lib/app/private/controller/load-action-modules.js
@@ -141,7 +141,6 @@ module.exports = function loadActionModules (sails, cb) {
         // Attempt to match the file path to the pattern of an action file,
         // and make sure it is either a function OR a dictionary containing
         // a function as its `fn` property.
-        console.log('')
         else if ((match = actionRegex.exec(filePath)) && (_.isFunction(moduleDef) || !_.isUndefined(moduleDef.machine) || !_.isUndefined(moduleDef.friendlyName) || _.isFunction(moduleDef.fn))) {
 
           // The action identity is the same as the module identity

--- a/lib/app/private/controller/load-action-modules.js
+++ b/lib/app/private/controller/load-action-modules.js
@@ -40,7 +40,7 @@ module.exports = function loadActionModules (sails, cb) {
       var garbage = [];
       // Traditional controllers are PascalCased and end with the word "Controller".
       var traditionalRegex = new RegExp('^((?:(?:.*)/)*([0-9A-Z][0-9a-zA-Z_]*))Controller\\..+$');
-      // Actions are kebab-cased by default 
+      // Actions are kebab-cased by default
       var actionRegex = null;
       switch(sails.config.casing.actions) {
         case 'camel-case':


### PR DESCRIPTION
We have strict architecture patterns for our folders and filenames to be written in camelCase. 

Sails (for actions) only supports kebab-case and we'd really like the option to specify the casings in our config to be able to name our actions `findOne.js` for example.

I've tested this and it works fine and doesn't throw any errors