### PR TITLE
[fixes #6965] Display underlying `raw` error on fail to lift app

### DIFF
--- a/lib/app/lift.js
+++ b/lib/app/lift.js
@@ -45,7 +45,9 @@ module.exports = function lift(configOverride, done) {
   done = done || function defaultCallback(err) {
     if (err) {
       sails.log.error('Failed to lift app:',err);
-      if(err.raw) sails.log.error('More details (raw):', err.raw);
+      if(err.raw) {
+        sails.log.error('More details (raw):', err.raw);
+      }
       sails.log.silly('(You are seeing the above error message because no custom callback was programmatically provided to `.lift()`.)');
       return;
     }

--- a/lib/app/lift.js
+++ b/lib/app/lift.js
@@ -45,6 +45,7 @@ module.exports = function lift(configOverride, done) {
   done = done || function defaultCallback(err) {
     if (err) {
       sails.log.error('Failed to lift app:',err);
+      if(err.raw) sails.log.error('More details (raw):', err.raw);
       sails.log.silly('(You are seeing the above error message because no custom callback was programmatically provided to `.lift()`.)');
       return;
     }


### PR DESCRIPTION
Some lift errors (e.g. `sails-mysql` initialisation errors) include a `.raw` more details error
message which is important i.e. specific model errors which cannot be corrected without 
the message details. This change displays these messages if they are present.

Closes https://github.com/balderdashy/sails/issues/6965.


