### PR TITLE
[proposal] Add 'UsageError' handling to `parseBlueprintOptions()`

### DIFF
--- a/lib/app/lift.js
+++ b/lib/app/lift.js
@@ -45,9 +45,7 @@ module.exports = function lift(configOverride, done) {
   done = done || function defaultCallback(err) {
     if (err) {
       sails.log.error('Failed to lift app:',err);
-      if(err.raw) {
-        sails.log.error('More details (raw):', err.raw);
-      }
+      if(err.raw) sails.log.error('More details (raw):', err.raw);
       sails.log.silly('(You are seeing the above error message because no custom callback was programmatically provided to `.lift()`.)');
       return;
     }

--- a/lib/app/lift.js
+++ b/lib/app/lift.js
@@ -45,7 +45,9 @@ module.exports = function lift(configOverride, done) {
   done = done || function defaultCallback(err) {
     if (err) {
       sails.log.error('Failed to lift app:',err);
-      if(err.raw) sails.log.error('More details (raw):', err.raw);
+      if(err.raw) {
+        sails.log.error('More details (raw):', err.raw);
+      }
       sails.log.silly('(You are seeing the above error message because no custom callback was programmatically provided to `.lift()`.)');
       return;
     }

--- a/lib/app/lift.js
+++ b/lib/app/lift.js
@@ -45,6 +45,7 @@ module.exports = function lift(configOverride, done) {
   done = done || function defaultCallback(err) {
     if (err) {
       sails.log.error('Failed to lift app:',err);
+      if(err.raw) sails.log.error('More details (raw):', err.raw);
       sails.log.silly('(You are seeing the above error message because no custom callback was programmatically provided to `.lift()`.)');
       return;
     }

--- a/lib/app/lift.js
+++ b/lib/app/lift.js
@@ -45,7 +45,6 @@ module.exports = function lift(configOverride, done) {
   done = done || function defaultCallback(err) {
     if (err) {
       sails.log.error('Failed to lift app:',err);
-      if(err.raw) sails.log.error('More details (raw):', err.raw);
       sails.log.silly('(You are seeing the above error message because no custom callback was programmatically provided to `.lift()`.)');
       return;
     }

--- a/lib/hooks/blueprints/actions/add.js
+++ b/lib/hooks/blueprints/actions/add.js
@@ -23,7 +23,15 @@ module.exports = function addToCollection (req, res) {
   // Set the blueprint action for parseBlueprintOptions.
   req.options.blueprintAction = 'add';
 
-  var queryOptions = parseBlueprintOptions(req);
+  var queryOptions;
+  try {
+    queryOptions = parseBlueprintOptions(req);
+  } catch (err) {
+    switch (err.name) {
+      case 'UsageError': return res.badRequest(formatUsageError(err, req));
+      default: return res.serverError(err);
+    }
+  }
   var Model = req._sails.models[queryOptions.using];
 
   var relation = queryOptions.alias;

--- a/lib/hooks/blueprints/actions/create.js
+++ b/lib/hooks/blueprints/actions/create.js
@@ -22,7 +22,15 @@ module.exports = function createRecord (req, res) {
   // Set the blueprint action for parseBlueprintOptions.
   req.options.blueprintAction = 'create';
 
-  var queryOptions = parseBlueprintOptions(req);
+  var queryOptions;
+  try {
+    queryOptions = parseBlueprintOptions(req);
+  } catch (err) {
+    switch (err.name) {
+      case 'UsageError': return res.badRequest(formatUsageError(err, req));
+      default: return res.serverError(err);
+    }
+  }
   var Model = req._sails.models[queryOptions.using];
 
   // Get the new record data.

--- a/lib/hooks/blueprints/actions/destroy.js
+++ b/lib/hooks/blueprints/actions/destroy.js
@@ -22,7 +22,15 @@ module.exports = function destroyOneRecord (req, res) {
   // Set the blueprint action for parseBlueprintOptions.
   req.options.blueprintAction = 'destroy';
 
-  var queryOptions = parseBlueprintOptions(req);
+  var queryOptions;
+  try {
+    queryOptions = parseBlueprintOptions(req);
+  } catch (err) {
+    switch (err.name) {
+      case 'UsageError': return res.badRequest(formatUsageError(err, req));
+      default: return res.serverError(err);
+    }
+  }
   var Model = req._sails.models[queryOptions.using];
 
   var criteria = {};

--- a/lib/hooks/blueprints/actions/find.js
+++ b/lib/hooks/blueprints/actions/find.js
@@ -24,7 +24,15 @@ module.exports = function findRecords (req, res) {
   // Set the blueprint action for parseBlueprintOptions.
   req.options.blueprintAction = 'find';
 
-  var queryOptions = parseBlueprintOptions(req);
+  var queryOptions;
+  try {
+    queryOptions = parseBlueprintOptions(req);
+  } catch (err) {
+    switch (err.name) {
+      case 'UsageError': return res.badRequest(formatUsageError(err, req));
+      default: return res.serverError(err);
+    }
+  }
   var Model = req._sails.models[queryOptions.using];
 
   Model

--- a/lib/hooks/blueprints/actions/findOne.js
+++ b/lib/hooks/blueprints/actions/findOne.js
@@ -22,7 +22,15 @@ module.exports = function findOneRecord (req, res) {
   // Set the blueprint action for parseBlueprintOptions.
   req.options.blueprintAction = 'findOne';
 
-  var queryOptions = parseBlueprintOptions(req);
+  var queryOptions;
+  try {
+    queryOptions = parseBlueprintOptions(req);
+  } catch (err) {
+    switch (err.name) {
+      case 'UsageError': return res.badRequest(formatUsageError(err, req));
+      default: return res.serverError(err);
+    }
+  }
   var Model = req._sails.models[queryOptions.using];
 
   // Only use the `where`, `select` or `omit` from the criteria (nothing else is valid for findOne).

--- a/lib/hooks/blueprints/actions/populate.js
+++ b/lib/hooks/blueprints/actions/populate.js
@@ -21,7 +21,15 @@ module.exports = function populate(req, res) {
   // Set the blueprint action for parseBlueprintOptions.
   req.options.blueprintAction = 'populate';
 
-  var queryOptions = parseBlueprintOptions(req);
+  var queryOptions;
+  try {
+    queryOptions = parseBlueprintOptions(req);
+  } catch (err) {
+    switch (err.name) {
+      case 'UsageError': return res.badRequest(formatUsageError(err, req));
+      default: return res.serverError(err);
+    }
+  }
   var Model = req._sails.models[queryOptions.using];
 
   var attrName = queryOptions.alias;

--- a/lib/hooks/blueprints/actions/remove.js
+++ b/lib/hooks/blueprints/actions/remove.js
@@ -20,7 +20,15 @@ module.exports = function remove(req, res) {
   // Set the blueprint action for parseBlueprintOptions.
   req.options.blueprintAction = 'remove';
 
-  var queryOptions = parseBlueprintOptions(req);
+  var queryOptions;
+  try {
+    queryOptions = parseBlueprintOptions(req);
+  } catch (err) {
+    switch (err.name) {
+      case 'UsageError': return res.badRequest(formatUsageError(err, req));
+      default: return res.serverError(err);
+    }
+  }
   var Model = req._sails.models[queryOptions.using];
 
   var relation = queryOptions.alias;

--- a/lib/hooks/blueprints/actions/replace.js
+++ b/lib/hooks/blueprints/actions/replace.js
@@ -23,7 +23,15 @@ module.exports = function replaceCollection (req, res) {
   // Set the blueprint action for parseBlueprintOptions.
   req.options.blueprintAction = 'replace';
 
-  var queryOptions = parseBlueprintOptions(req);
+  var queryOptions;
+  try {
+    queryOptions = parseBlueprintOptions(req);
+  } catch (err) {
+    switch (err.name) {
+      case 'UsageError': return res.badRequest(formatUsageError(err, req));
+      default: return res.serverError(err);
+    }
+  }
   var Model = req._sails.models[queryOptions.using];
 
   var relation = queryOptions.alias;

--- a/lib/hooks/blueprints/actions/update.js
+++ b/lib/hooks/blueprints/actions/update.js
@@ -23,7 +23,15 @@ module.exports = function updateOneRecord (req, res) {
   // Set the blueprint action for parseBlueprintOptions.
   req.options.blueprintAction = 'update';
 
-  var queryOptions = parseBlueprintOptions(req);
+  var queryOptions;
+  try {
+    queryOptions = parseBlueprintOptions(req);
+  } catch (err) {
+    switch (err.name) {
+      case 'UsageError': return res.badRequest(formatUsageError(err, req));
+      default: return res.serverError(err);
+    }
+  }
   var Model = req._sails.models[queryOptions.using];
 
   var criteria = {};


### PR DESCRIPTION
Custom `parseBlueprintOptions()` handling is configurable (see [here](https://sailsjs.com/documentation/reference/configuration/sails-config-blueprints)) 
but currently does not enable returning UsageError's  view via
`res.badRequest()` in the same way as errors that occur later
during the blueprint processing e.g. [create action](https://github.com/balderdashy/sails/blob/master/lib/hooks/blueprints/actions/create.js#L102)
Handling of UsageError's using `res.badRequest()` is added in this PR.