### PR TITLE
[proposal] Allow per-model blueprint `_config` in model definition

### DIFF
--- a/lib/app/private/controller/load-action-modules.js
+++ b/lib/app/private/controller/load-action-modules.js
@@ -7,6 +7,7 @@ var _ = require('@sailshq/lodash');
 var includeAll = require('include-all');
 var flaverr = require('flaverr');
 var helpRegisterAction = require('./help-register-action');
+var mergeDictionaries = require('merge-dictionaries');
 
 
 /**
@@ -85,7 +86,10 @@ module.exports = function loadActionModules (sails, cb) {
             // config instead of trying to load it as an action.
             if (actionName === '_config') {
               if (sails.config.blueprints) {
-                sails.config.blueprints._controllers[identity.toLowerCase()] = action;
+                var identityLC = identity.toLowerCase();
+                sails.config.blueprints._controllers[identityLC] = mergeDictionaries(
+                  action, sails.config.blueprints._controllers[identityLC] || {},
+                );
               }
               return;
             }

--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -323,6 +323,20 @@ module.exports = function(sails) {
             sails.log.debug('The use of `.attributes.json` files is deprecated, and support will be removed in a future release of Sails.');
           }
 
+          /*
+           * Check for any '_config' settings in the model definition and merge
+           * into the blueprint controller config settings taken from controller.
+           */
+          _.each(models, function(modelDef, modelIdentity){
+            if(_.isPlainObject(modelDef._config)) {
+              if (sails.config.blueprints) {
+                sails.config.blueprints._controllers[modelIdentity] = mergeDictionaries(
+                  modelDef._config, sails.config.blueprints._controllers[modelIdentity] || {},
+                );
+              }
+            }
+          });
+
           return cb(undefined, _.merge(models, supplements));
         }));
         // ---------------------------------------------------------


### PR DESCRIPTION
Currently, the model controller file may contain per-model configuration
settings in a `_config` element.

However, where model definitions do not contain any specific
controller code there is often many models for which no controller
definition exists.

This change allows the `_config` element to be placed in the
model definition, and this config is merged into the controller
`_config` settings (if any).

See:
1. https://sailsjs.com/documentation/reference/blueprint-api


