### PR TITLE
[proposal] Set `blueprintAction` earlier (bind rather than exec)

### DIFF
--- a/lib/hooks/blueprints/actions/add.js
+++ b/lib/hooks/blueprints/actions/add.js
@@ -21,7 +21,8 @@ module.exports = function addToCollection (req, res) {
   var parseBlueprintOptions = req.options.parseBlueprintOptions || req._sails.config.blueprints.parseBlueprintOptions;
 
   // Set the blueprint action for parseBlueprintOptions.
-  req.options.blueprintAction = 'add';
+  // (MOVED: The setting of `blueprintAction` has been moved to bindShadowRoutes() so present when policy middleware runs)
+  // req.options.blueprintAction = 'add';
 
   var queryOptions = parseBlueprintOptions(req);
   var Model = req._sails.models[queryOptions.using];

--- a/lib/hooks/blueprints/actions/create.js
+++ b/lib/hooks/blueprints/actions/create.js
@@ -20,7 +20,8 @@ module.exports = function createRecord (req, res) {
   var parseBlueprintOptions = req.options.parseBlueprintOptions || req._sails.config.blueprints.parseBlueprintOptions;
 
   // Set the blueprint action for parseBlueprintOptions.
-  req.options.blueprintAction = 'create';
+  // (MOVED: The setting of `blueprintAction` has been moved to bindShadowRoutes() so present when policy middleware runs)
+  // req.options.blueprintAction = 'create';
 
   var queryOptions = parseBlueprintOptions(req);
   var Model = req._sails.models[queryOptions.using];

--- a/lib/hooks/blueprints/actions/destroy.js
+++ b/lib/hooks/blueprints/actions/destroy.js
@@ -20,7 +20,8 @@ module.exports = function destroyOneRecord (req, res) {
   var parseBlueprintOptions = req.options.parseBlueprintOptions || req._sails.config.blueprints.parseBlueprintOptions;
 
   // Set the blueprint action for parseBlueprintOptions.
-  req.options.blueprintAction = 'destroy';
+  // (MOVED: The setting of `blueprintAction` has been moved to bindShadowRoutes() so present when policy middleware runs)
+  // req.options.blueprintAction = 'destroy';
 
   var queryOptions = parseBlueprintOptions(req);
   var Model = req._sails.models[queryOptions.using];

--- a/lib/hooks/blueprints/actions/find.js
+++ b/lib/hooks/blueprints/actions/find.js
@@ -22,7 +22,8 @@ module.exports = function findRecords (req, res) {
   var parseBlueprintOptions = req.options.parseBlueprintOptions || req._sails.config.blueprints.parseBlueprintOptions;
 
   // Set the blueprint action for parseBlueprintOptions.
-  req.options.blueprintAction = 'find';
+  // (MOVED: The setting of `blueprintAction` has been moved to bindShadowRoutes() so present when policy middleware runs)
+  // req.options.blueprintAction = 'find';
 
   var queryOptions = parseBlueprintOptions(req);
   var Model = req._sails.models[queryOptions.using];

--- a/lib/hooks/blueprints/actions/findOne.js
+++ b/lib/hooks/blueprints/actions/findOne.js
@@ -20,7 +20,8 @@ module.exports = function findOneRecord (req, res) {
   var parseBlueprintOptions = req.options.parseBlueprintOptions || req._sails.config.blueprints.parseBlueprintOptions;
 
   // Set the blueprint action for parseBlueprintOptions.
-  req.options.blueprintAction = 'findOne';
+  // (MOVED: The setting of `blueprintAction` has been moved to bindShadowRoutes() so present when policy middleware runs)
+  // req.options.blueprintAction = 'findOne';
 
   var queryOptions = parseBlueprintOptions(req);
   var Model = req._sails.models[queryOptions.using];

--- a/lib/hooks/blueprints/actions/populate.js
+++ b/lib/hooks/blueprints/actions/populate.js
@@ -19,7 +19,8 @@ module.exports = function populate(req, res) {
   var parseBlueprintOptions = req.options.parseBlueprintOptions || req._sails.config.blueprints.parseBlueprintOptions;
 
   // Set the blueprint action for parseBlueprintOptions.
-  req.options.blueprintAction = 'populate';
+  // (MOVED: The setting of `blueprintAction` has been moved to bindShadowRoutes() so present when policy middleware runs)
+  // req.options.blueprintAction = 'populate';
 
   var queryOptions = parseBlueprintOptions(req);
   var Model = req._sails.models[queryOptions.using];

--- a/lib/hooks/blueprints/actions/remove.js
+++ b/lib/hooks/blueprints/actions/remove.js
@@ -18,7 +18,8 @@ module.exports = function remove(req, res) {
   var parseBlueprintOptions = req.options.parseBlueprintOptions || req._sails.config.blueprints.parseBlueprintOptions;
 
   // Set the blueprint action for parseBlueprintOptions.
-  req.options.blueprintAction = 'remove';
+  // (MOVED: The setting of `blueprintAction` has been moved to bindShadowRoutes() so present when policy middleware runs)
+  // req.options.blueprintAction = 'remove';
 
   var queryOptions = parseBlueprintOptions(req);
   var Model = req._sails.models[queryOptions.using];

--- a/lib/hooks/blueprints/actions/replace.js
+++ b/lib/hooks/blueprints/actions/replace.js
@@ -21,7 +21,8 @@ module.exports = function replaceCollection (req, res) {
   var parseBlueprintOptions = req.options.parseBlueprintOptions || req._sails.config.blueprints.parseBlueprintOptions;
 
   // Set the blueprint action for parseBlueprintOptions.
-  req.options.blueprintAction = 'replace';
+  // (MOVED: The setting of `blueprintAction` has been moved to bindShadowRoutes() so present when policy middleware runs)
+  // req.options.blueprintAction = 'replace';
 
   var queryOptions = parseBlueprintOptions(req);
   var Model = req._sails.models[queryOptions.using];

--- a/lib/hooks/blueprints/actions/update.js
+++ b/lib/hooks/blueprints/actions/update.js
@@ -21,7 +21,8 @@ module.exports = function updateOneRecord (req, res) {
   var parseBlueprintOptions = req.options.parseBlueprintOptions || req._sails.config.blueprints.parseBlueprintOptions;
 
   // Set the blueprint action for parseBlueprintOptions.
-  req.options.blueprintAction = 'update';
+  // (MOVED: The setting of `blueprintAction` has been moved to bindShadowRoutes() so present when policy middleware runs)
+  // req.options.blueprintAction = 'update';
 
   var queryOptions = parseBlueprintOptions(req);
   var Model = req._sails.models[queryOptions.using];

--- a/lib/hooks/blueprints/index.js
+++ b/lib/hooks/blueprints/index.js
@@ -337,7 +337,7 @@ module.exports = function(sails) {
             var shortcutRoute = util.format(template, baseShortcutRoute);
             // Bind it to the appropriate action, adding in some route options including a deep clone of the model associations.
             // The clone prevents the blueprint action from accidentally altering the model definition in any way.
-            sails.router.bind(shortcutRoute, identity + '/' + blueprintActionName, null, { model: identity, associations: _.cloneDeep(Model.associations), autoWatch: sails.config.blueprints.autoWatch });
+            sails.router.bind(shortcutRoute, identity + '/' + blueprintActionName, null, { model: identity, blueprintAction: blueprintActionName, associations: _.cloneDeep(Model.associations), autoWatch: sails.config.blueprints.autoWatch });
           }
 
           function _bindAssocRoute(template, blueprintActionName, alias) {
@@ -345,7 +345,7 @@ module.exports = function(sails) {
             var assocRoute = util.format(template, baseShortcutRoute, alias);
             // Bind it to the appropriate action, adding in some route options including a deep clone of the model associations.
             // The clone prevents the blueprint action from accidentally altering the model definition in any way.
-            sails.router.bind(assocRoute, identity + '/' + blueprintActionName, null, { model: identity, alias: alias, associations: _.cloneDeep(Model.associations), autoWatch: sails.config.blueprints.autoWatch  });
+            sails.router.bind(assocRoute, identity + '/' + blueprintActionName, null, { model: identity, blueprintAction: blueprintActionName, alias: alias, associations: _.cloneDeep(Model.associations), autoWatch: sails.config.blueprints.autoWatch  });
           }
 
         });
@@ -425,7 +425,7 @@ module.exports = function(sails) {
             var restRoute = util.format(template, baseRestRoute);
             // Bind it to the appropriate action, adding in some route options including a deep clone of the model associations.
             // The clone prevents the blueprint action from accidentally altering the model definition in any way.
-            sails.router.bind(restRoute, identity + '/' + blueprintActionName, null, { model: identity, associations: _.cloneDeep(Model.associations), autoWatch: sails.config.blueprints.autoWatch  });
+            sails.router.bind(restRoute, identity + '/' + blueprintActionName, null, { model: identity, blueprintAction: blueprintActionName, associations: _.cloneDeep(Model.associations), autoWatch: sails.config.blueprints.autoWatch  });
           }
 
           function _bindAssocRoute(template, blueprintActionName, alias) {
@@ -433,7 +433,7 @@ module.exports = function(sails) {
             var assocRoute = util.format(template, baseRestRoute, alias);
             // Bind it to the appropriate action, adding in some route options including a deep clone of the model associations.
             // The clone prevents the blueprint action from accidentally altering the model definition in any way.
-            sails.router.bind(assocRoute, identity + '/' + blueprintActionName, null, { model: identity, alias: alias, associations: _.cloneDeep(Model.associations), autoWatch: sails.config.blueprints.autoWatch  });
+            sails.router.bind(assocRoute, identity + '/' + blueprintActionName, null, { model: identity, blueprintAction: blueprintActionName, alias: alias, associations: _.cloneDeep(Model.associations), autoWatch: sails.config.blueprints.autoWatch  });
           }
 
         });


### PR DESCRIPTION
Currently `req.options.blueprintAction` is set when executing the
blueprint action (e.g. `lib/hooks/blueprints/actions/find.js`),
immediately before `parseBlueprintOptions()` is called.

This has the effect that it is not available to policies (or other middleware)
processing the route (e.g. checking authorization).

This change moves setting `req.options.blueprintAction` to the point
at which the blueprint routes are bound.

See:
1. https://github.com/balderdashy/sails/blob/c7900af9864a10bde3fdc83097d99b82cddc713a/lib/hooks/blueprints/actions/find.js#L25


