### PR TITLE
[patch] when creating many to many with through association

### DIFF
--- a/lib/hooks/blueprints/actions/create.js
+++ b/lib/hooks/blueprints/actions/create.js
@@ -43,6 +43,8 @@ module.exports = function createRecord (req, res) {
       _.isArray(data[attrName]) && data[attrName].length > 0 &&
       // Does this plural association have an inverse attribute on the related model?
       attrDef.via &&
+      // check that this is not a many-to-many through relation
+      !attrDef.through &&
       // Is that inverse attribute a singular association, making this a many-to-one relationship?
       req._sails.models[attrDef.collection].attributes[attrDef.via].model
     ) {


### PR DESCRIPTION
With the following models:

`
// myApp/api/models/User.js
module.exports = {
  attributes: {
    name: {
      type: 'string'
    },
    pets:{
      collection: 'pet',
      via: 'owner',
      through: 'petuser'
    }
  }
}

// myApp/api/models/Pet.js
module.exports = {
  attributes: {
    name: {
      type: 'string'
    },
    color: {
      type: 'string'
    },
    owners:{
      collection: 'user',
      via: 'pet',
      through: 'petuser'
    }
  }
}

// myApp/api/models/PetUser.js
module.exports = {
  attributes: {
    owner:{
      model:'user'
    },
    pet: {
      model: 'pet'
    }
  }
}
`
And calling the following blueprint api request:

`POST /user -d { "name": "username", "pets": [1,2] }`

Will give an error on:
error: Sending 500 ("Server Error") response: 
 TypeError: Cannot read property 'model' of undefined
    at /Users/joshua/Gloow/falconone/node_modules/sails/lib/hooks/blueprints/actions/create.js:50:69

Because
     req._sails.models[attrDef.collection].attributes[attrDef.via].model

 is not defined on the referenced collection (rather on the through model).

Checking that this is not a many - to many association with a through table also makes sense here because it would not require deleting previous parents.


