### PR TITLE
[fixes #7063] add toJSON so pubsub obeys customToJSON

### DIFF
--- a/lib/hooks/blueprints/actions/destroy.js
+++ b/lib/hooks/blueprints/actions/destroy.js
@@ -66,7 +66,7 @@ module.exports = function destroyOneRecord (req, res) {
       }//-•
 
       if (req._sails.hooks.pubsub) {
-        Model._publishDestroy(criteria[Model.primaryKey], !req._sails.config.blueprints.mirror && req, {previous: record});
+        Model._publishDestroy(criteria[Model.primaryKey], !req._sails.config.blueprints.mirror && req, {previous: record.toJSON()});
         if (req.isSocket) {
           Model.unsubscribe(req, [record[Model.primaryKey]]);
           Model._retire(record);

--- a/lib/hooks/blueprints/actions/update.js
+++ b/lib/hooks/blueprints/actions/update.js
@@ -96,7 +96,7 @@ module.exports = function updateOneRecord (req, res) {
         // > TODO: why is that important?
         var pk = updatedRecord[Model.primaryKey];
         Model._publishUpdate(pk, _.cloneDeep(queryOptions.valuesToSet), !req.options.mirror && req, {
-          previous: _.cloneDeep(matchingRecord)
+          previous: _.cloneDeep(matchingRecord.toJSON())
         });
       }//ﬁ
 


### PR DESCRIPTION
Addresses my issue (#7063).

_publishUpdate and _publishDestroy were being passed 'previous' records in the options argument in the destroy and update blueprint actions and then being published without ever having a toJSON() called on them.  This caused the 'customToJSON' defined on the model to not be obeyed.