### PR TITLE
[proposal] Allow subcriteria JSON object in blueprint populate

### DIFF
--- a/lib/hooks/blueprints/parse-blueprint-options.js
+++ b/lib/hooks/blueprints/parse-blueprint-options.js
@@ -220,6 +220,8 @@ module.exports = function parseBlueprintOptions(req) {
       // e.g.:
       //   /model?populate=alias1,alias2,alias3
       //   /model?populate=[alias1,alias2,alias3]
+      // also can be an object
+      //   /model?populate={"alias1": {"attribute": Number}}
       if (req.param('populate')) {
 
         queryOptions.populates = (function getPopulates() {
@@ -233,7 +235,12 @@ module.exports = function parseBlueprintOptions(req) {
           attributes = attributes.split(',');
           // Trim whitespace off of the attributes.
           attributes = _.reduce(attributes, function(memo, attribute) {
-            memo[attribute.trim()] = {};
+            try {
+              attribute = JSON.parse(attribute);
+              memo = {...memo, ...attribute};
+            } catch(unusedErr) {
+              memo[attribute.trim()] = {};
+            }
             return memo;
           }, {});
           return attributes;


### PR DESCRIPTION
Currently, you can only do with populate:

```
/model?populate=alias1,alias2,alias3
```

There is subcriteria to [populate ](https://sailsjs.com/documentation/reference/waterline-orm/queries/populate). That lets us - "filter, sort, and limit the array of associated records".

PR will enable JSON objects (like in "where") to be passed in to populate I.E.:

```
/model?populate={"alias1": {"attribute": Any}}
```

Can still pass regular way:

```
/model?populate=alias1,alias2,alias3
```

And can mix:

```
/model?populate={"alias1": {"id": 1}},alias2,{"alias3": {"sort": "id DESC"}}
```

