### PR TITLE
[patch] change typo --no-front-end to --no-frontend in CLI flag help output

### DIFF
--- a/bin/sails.js
+++ b/bin/sails.js
@@ -63,7 +63,7 @@ cmd.action(require('./sails-lift'));
 // $ sails new <appname>
 cmd = program.command('new [path_to_new_app]');
 // cmd.option('--dry');
-cmd.option('--no-front-end', 'Don\'t generate "assets", "views" or "task" folders.');
+cmd.option('--no-frontend', 'Don\'t generate "assets", "views" or "task" folders.');
 cmd.option('--fast', 'Don\'t install node modules after generating app.');
 cmd.usage('[path_to_new_app]');
 cmd.unknownOption = NOOP;


### PR DESCRIPTION
Currently when you run `sails new -h`, you get as part of the help output a reference to `--no-front-end` flag but actually the flag is `--no-frontend`
<img width="750" alt="Screenshot 2021-03-21 at 11 21 29" src="https://user-images.githubusercontent.com/24433274/111901306-96a28600-8a37-11eb-859f-0bb4dd14f217.png">
