### PR TITLE
[patch] Fix node deprecation warnings

### DIFF
--- a/bin/private/read-repl-history-and-start-transcribing.js
+++ b/bin/private/read-repl-history-and-start-transcribing.js
@@ -45,7 +45,7 @@ module.exports = function readReplHistoryAndBeginTranscribing(repl, file) {
 
     // Update the REPL history file accordingly.
     if (code && code !== '.history') {
-      var buffer = new Buffer(code + '\n');
+      var buffer = Buffer.from(code + '\n');
       // Send all arguments to fs.write to support Node v0.10.x.
       fs.write(fd, buffer, 0, buffer.length, null, function (err /*, written */){
         if (!err) {

--- a/bin/private/read-repl-history-and-start-transcribing.js
+++ b/bin/private/read-repl-history-and-start-transcribing.js
@@ -27,9 +27,9 @@ module.exports = function readReplHistoryAndBeginTranscribing(repl, file) {
   if (historyFileExists) {
 
     // If so, then read it, and set the initial REPL history.
-    repl.rli.history = fs.readFileSync(file, 'utf-8').split('\n').reverse();
-    repl.rli.history.shift();
-    repl.rli.historyIndex = -1;
+    repl.history = fs.readFileSync(file, 'utf-8').split('\n').reverse();
+    repl.history.shift();
+    repl.historyIndex = -1;
 
   }//>-
 
@@ -41,7 +41,7 @@ module.exports = function readReplHistoryAndBeginTranscribing(repl, file) {
   var alreadyLoggedWarningAboutREPLHistory;
 
   // Bind alistener that will fire each time a newline is entered on the REPL.
-  repl.rli.addListener('line', function (code) {
+  repl.addListener('line', function (code) {
 
     // Update the REPL history file accordingly.
     if (code && code !== '.history') {
@@ -62,11 +62,11 @@ module.exports = function readReplHistoryAndBeginTranscribing(repl, file) {
       });// _∏_
     }
     else {
-      repl.rli.historyIndex++;
-      repl.rli.history.pop();
+      repl.historyIndex++;
+      repl.history.pop();
     }
 
-  });//</every time repl.rli emits a "line" event>
+  });//</every time repl emits a "line" event>
 
   // Bind a one-time-use listener that will fire when the process exits.
   process.once('exit', function () {

--- a/lib/hooks/http/initialize.js
+++ b/lib/hooks/http/initialize.js
@@ -82,7 +82,7 @@ module.exports = function(sails) {
         // so if we detect an array, then transform it back into a buffer.
         _.each(['key', 'cert', 'pfx'], function _eachSSLOption(sslOption) {
           if (_.isArray(serverOptions[sslOption])) {
-            serverOptions[sslOption] = new Buffer(serverOptions[sslOption]);
+            serverOptions[sslOption] = Buffer.from(serverOptions[sslOption]);
           }
         });
         // ^^^ The following is probably not relevant anymore, because `_.merge()`


### PR DESCRIPTION
Fixes Node deprecation warnings [DEP0124](https://nodejs.org/api/deprecations.html#DEP0124) when the server starts, and [DEP0005](https://nodejs.org/api/deprecations.html#DEP0005) when starting the server with `sails console`

Tested in a new app with my local sails linked, everything worked as expected, no deprecation warnings.