### PR TITLE
[proposal] Enable module cache during sails load

### DIFF
--- a/lib/hooks/moduleloader/index.js
+++ b/lib/hooks/moduleloader/index.js
@@ -340,7 +340,8 @@ module.exports = function(sails) {
         dirname     : sails.config.paths.services,
         filter      : /^(.+)\.(?:(?!md|txt).)+$/,
         depth     : 1,
-        caseSensitive : true
+        caseSensitive : true,
+        force: false
       }, bindToSails(cb));
     },
 


### PR DESCRIPTION
The fact that sails doesn't pass the force argument to includeAll causes the several services to being required multiple times which impacts the  perfomance.