### PR TITLE
[proposal] Add documentation regarding a breaking change in SSL connection syntax

### DIFF
--- a/docs/concepts/extending-sails/Adapters/adapterList.md
+++ b/docs/concepts/extending-sails/Adapters/adapterList.md
@@ -71,6 +71,7 @@ url: 'postgresql://user:password@host:port/database',
 
 > + The default port for PostgreSQL is `5432`.
 > + In addition to `adapter` and `url`, you might also need to set `ssl: true`.  This depends on where your PostgreSQL database server is hosted.  For example, `ssl: true` is required when connecting to Heroku's hosted PostgreSQL service.
+> + Note that in `pg@8.0` the syntax was updated to `ssl: { rejectUnauthorized: false }`.
 
 ### sails-mongo
 


### PR DESCRIPTION
The update referenced in this note is available to read here -
https://node-postgres.com/announcements#2020-02-25

Without adding the new ssl connection attribute, database connection will fail.