### PR TITLE
Bump skipper to 0.8.0 to fix os.tmpDir issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "semver": "5.1.0",
     "serve-favicon": "2.3.0",
     "serve-static": "1.10.2",
-    "skipper": "~0.7.0",
+    "skipper": "~0.8.0",
     "uid-safe": "1.1.0",
     "walk": "2.3.9"
   },


### PR DESCRIPTION
The issue is os.tmpDir has been deprecated and is being used in multiparty which is a dependency of Skipper 0.7.0. Updating to 0.8.0 fixes this: https://github.com/pillarjs/multiparty/issues/164#issuecomment-279394122