### PR TITLE
[fixes #7201] Bump up prompt to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "parseurl": "1.3.2",
     "path-to-regexp": "1.5.3",
     "pluralize": "1.2.1",
-    "prompt": "1.1.0",
+    "prompt": "1.2.1",
     "rc": "1.2.8",
     "router": "1.3.2",
     "rttc": "^10.0.0-0",


### PR DESCRIPTION
This is done to fix the rogue colors package. Prompt@1.2.1 pins colors@1.4.0.

Issue: https://github.com/balderdashy/sails/issues/7201

