### PR TITLE
Pull liftTimeout to http hook defaults

### DIFF
--- a/lib/hooks/http/index.js
+++ b/lib/hooks/http/index.js
@@ -29,6 +29,9 @@ module.exports = function(sails) {
       // Port to run this app on
       port: 1337,
 
+      // How long before warning Sails is taking too long to lift.
+      liftTimeout: 4000,
+
       // SSL cert settings end up here
       ssl: {},
 

--- a/lib/hooks/http/start.js
+++ b/lib/hooks/http/start.js
@@ -12,9 +12,7 @@ module.exports = function (sails) {
 
     // Used to warn about possible issues if starting the server is taking a long time
     var liftAbortTimer;
-    var liftTimeout = sails.config.liftTimeout || 4000;
-    // TODO: pull this defaulting into `defaults`
-    // and also ensure this config is properly documented.
+    var liftTimeout = sails.config.liftTimeout;
 
     async.auto({
 


### PR DESCRIPTION
This resolves a TODO comment which says to pull the `liftTimeout` defaulting in the `startServer()` function to the hooks definition defaults.