### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ node_js:
   - "10"
   - "12"
   - "14"
-  - "node"
+  - "16"
 
 branches:
   only:


### PR DESCRIPTION
Changes: 
- Updated the Travis CI config file to use node 16 instead of the latest version. (See https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/5 for more info)