### PR TITLE
Docs: Added documentation for .retry and .timeout for helpers

### DIFF
--- a/docs/concepts/Helpers/Helpers.md
+++ b/docs/concepts/Helpers/Helpers.md
@@ -165,6 +165,12 @@ sails.log('Ok it worked!  The result is:', result);
 
 > This is roughly the same usage you might already be familiar with from [model methods](sailsjs.com/documentation/concepts/models-and-orm/models) like `.create()`.
 
+Additionally, you can add two different chainable methods on helper invocation: `.timeout()` and `.retry()`:
+
+```javascript
+var result = await sails.hellpers.formatWelcomeMessage('Dolly').timeout(5000).retry();
+```
+
 ##### Synchronous usage
 
 If a helper declares the `sync` property, you can also call it without `await`:


### PR DESCRIPTION
Added documentation for `.retry` and `.timeout` for helpers as found in the following locations:

- [Internal Fleet.dm Code](https://github.com/fleetdm/fleet/blob/main/website/api/controllers/account/update-billing-card.js#L60)
- [Sails Changelog](https://github.com/steventhanna/sails/blob/master/CHANGELOG.md)
- `.timeout` in [Parley](https://github.com/mikermcneil/parley/blob/master/lib/private/Deferred.js#L698)