### PR TITLE
Update ExampleHelper.md to use `const`

### DIFF
--- a/docs/concepts/Helpers/ExampleHelper.md
+++ b/docs/concepts/Helpers/ExampleHelper.md
@@ -52,7 +52,7 @@ module.exports = {
   fn: async function (inputs, exits) {
 
     // Run the query
-    var users = await User.find({
+    const users = await User.find({
       active: true,
       lastLogin: { '>': inputs.activeSince }
     })
@@ -77,13 +77,13 @@ module.exports = {
 To call this helper from app code using the default options (in an action, for example), we would use:
 
 ```javascript
-var users = await sails.helpers.getRecentUsers();
+const users = await sails.helpers.getRecentUsers();
 ```
 
 To alter the criteria for the returned users, we could pass in some values:
 
 ```javascript
-var users = await sails.helpers.getRecentUsers(50);
+const users = await sails.helpers.getRecentUsers(50);
 ```
 
 Or, to get the 10 most recent users who have logged in since St. Patrick's Day, 2017:
@@ -109,7 +109,7 @@ await sails.helpers.getRecentUsers.with({
 Finally, to handle the `noUsersFound` exit explicitly rather than simply treating it like any other error, we can use [`.intercept()`](https://sailsjs.com/documentation/reference/waterline-orm/queries/intercept) or [`.tolerate()`](https://sailsjs.com/documentation/reference/waterline-orm/queries/tolerate):
 
 ```javascript
-var users = await sails.helpers.getRecentUsers(10)
+const users = await sails.helpers.getRecentUsers(10)
 .tolerate('noUsersFound', ()=>{
   // ... handle the case where no users were found. For example:
   sails.log.verbose(
@@ -121,7 +121,7 @@ var users = await sails.helpers.getRecentUsers(10)
 ```
 
 ```javascript
-var users = await sails.helpers.getRecentUsers(10)
+const users = await sails.helpers.getRecentUsers(10)
 .intercept('noUsersFound', ()=>{
   return new Error('Inconceivably, no active users were found for that timeframe.');
 });


### PR DESCRIPTION
The sails docs use `var` in most example code. This is an outdated practice as the newer alternatives of `let` and `const` offer more granular control over variable scoping in a way that is preferable 95+% of the time. The use of `var` in the docs gives new users the impression that sails is dated. Updating the docs to use `const` or occasionally `let` in the examples will make sails more appealing.

I'm opening this PR as a one-off for a single page in the hopes of getting feedback on whether the sails team agrees that this change is appropriate before I more holistically propose changes to a broader range of sails docs to update them similarly.


