### PR TITLE
bump expressjs to version 4.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cookie-signature": "1.1.0",
     "csurf": "1.10.0",
     "ejs": "3.1.7",
-    "express": "4.17.1",
+    "express": "4.17.3",
     "express-session": "1.17.0",
     "flaverr": "^1.10.0",
     "glob": "7.1.2",


### PR DESCRIPTION
update expressjs to patched version to mitigate CVE-2022-24999 
fixes #7267


