### PR TITLE
Improve virtual request parsing

### DIFF
--- a/lib/router/req.js
+++ b/lib/router/req.js
@@ -53,9 +53,9 @@ module.exports = function buildRequest (_req) {
           delete _req.headers[headerKey];
         }
         // Make sure all remaining headers are strings
-        if (typeof headerVal !== 'string') {
+        if (typeof _req.headers[headerKey] !== 'string') {
           try {
-            headerVal = ''+headerVal+'';
+            _req.headers[headerKey] = ''+_req.headers[headerKey];
             // FUTURE: This behavior is likely being relied upon by apps, so we can't just change it.
             // But in retrospect, it would probably be better to straight-up reject this here if it's not
             // a string, since HTTP header values are always supposed to be strings; or at least primitives.

--- a/lib/router/req.js
+++ b/lib/router/req.js
@@ -46,22 +46,27 @@ module.exports = function buildRequest (_req) {
   }
   else {
 
-    // TODO: send a PR to mock-req with a fix for this
     if (_req.headers && typeof _req.headers === 'object') {
-      // Strip undefined headers
-      _.each(_req.headers, function (headerVal, headerKey) {
-        if (_.isUndefined(headerVal)){
+      for (let headerKey of Object.keys(_req.headers)) {
+        // Strip undefined headers
+        if (undefined === _req.headers[headerKey]) {
           delete _req.headers[headerKey];
         }
-      });
-      // Make sure all remaining headers are strings
-      _req.headers = _.mapValues(_req.headers, function (headerVal /*, headerKey*/) {
+        // Make sure all remaining headers are strings
         if (typeof headerVal !== 'string') {
-          headerVal = ''+headerVal+'';
+          try {
+            headerVal = ''+headerVal+'';
+            // FUTURE: This behavior is likely being relied upon by apps, so we can't just change it.
+            // But in retrospect, it would probably be better to straight-up reject this here if it's not
+            // a string, since HTTP header values are always supposed to be strings; or at least primitives.
+            // So maybe reject non-primitives, reject `null`, and then accept primitives, but be smart about
+            // this, especially in the context of what the client is doing.
+          } catch (unusedErr) {
+            delete _req.headers[headerKey];
+          }
         }
-        return headerVal;
-      });
-    }
+      }//∞
+    }//ﬁ
 
     // Create a mock IncomingMessage stream.
     req = new MockReq({


### PR DESCRIPTION
Relevant for socket.io usage, and usage from tests.  (`sails.request()`)


