### PR TITLE
FIX cloneDeep valuesToSet in update blueprints action

### DIFF
--- a/lib/hooks/blueprints/actions/update.js
+++ b/lib/hooks/blueprints/actions/update.js
@@ -61,7 +61,7 @@ module.exports = function updateOneRecord (req, res) {
 
     // This should only update a single record
     Model.updateOne(_.cloneDeep(criteria))
-    .set(queryOptions.valuesToSet)
+    .set(_.cloneDeep(queryOptions.valuesToSet))
     .meta(queryOptions.meta)
     .exec(function (err, updatedRecord) {
 


### PR DESCRIPTION
Hello,
I had a problem with the sending of addedTo and removedTo socket notifications when I updated a record with the default update blueprints action. After an investigation, I found the bug was caused by a mutation of the  queryOptions.valuesToSet object after the updateOne fonction. I use mongoDB as database. I just added a cloneDeep to prevent the mutation. After the fix, I receive now the addedTo and removedTo socket notifications.
Thanks for your time looking at this
@mikermcneil 