### PR TITLE
RPS hook: Future-proof

### DIFF
--- a/lib/hooks/pubsub/index.js
+++ b/lib/hooks/pubsub/index.js
@@ -274,15 +274,14 @@ module.exports = function(sails) {
           sails.log.debug('Wrapping it in an array for you this time...');
         }
 
-        _.each(ids,function (id) {
+        for (let id of ids) {
           // Attempt to join the room for the specified instance.
-          if (sails.sockets.join( socket, self._room(id) )) {
-            sails.log.silly(
-              'Subscribed to the ' +
-              self.globalId + ' with id=' + id + '\t(room :: ' + self._room(id) + ')'
-            );
-          }
-        });
+          sails.sockets.join( socket, self._room(id) );
+          sails.log.silly(
+            'Subscribed to the ' +
+            self.globalId + ' with id=' + id + '\t(room :: ' + self._room(id) + ')'
+          );
+        }//∞
       },
 
       /**
@@ -325,15 +324,14 @@ module.exports = function(sails) {
           sails.log.debug('Wrapping it in an array for you this time...');
         }
 
-        _.each(ids,function (id) {
+        for (let id of ids) {
           // Attempt to leave the room for the specified instance.
-          if (sails.sockets.leave( socket, self._room(id))) {
-            sails.log.silly(
-              'Unsubscribed from the ' +
-              self.globalId + ' with id=' + id + '\t(room :: ' + self._room(id) + ')'
-            );
-          }
-        });
+          sails.sockets.leave( socket, self._room(id));
+          sails.log.silly(
+            'Unsubscribed from the ' +
+            self.globalId + ' with id=' + id + '\t(room :: ' + self._room(id) + ')'
+          );
+        }//∞
       },
 
       /**


### PR DESCRIPTION
Adjusts for unnecessary `return true` pointed out in balderdashy/sails-hook-sockets#50, which will eventually no longer be a thing.  (Starting with the rps hook not using it.)


