### PR TITLE
Dependencies: bump `skipper` and `captains-log` versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@sailshq/lodash": "^3.10.2",
     "async": "2.6.4",
-    "captains-log": "^2.0.0",
+    "captains-log": "^2.0.5",
     "chalk": "2.3.0",
     "commander": "2.11.0",
     "common-js-file-extensions": "1.0.2",
@@ -63,7 +63,7 @@
     "semver": "7.5.2",
     "serve-favicon": "2.4.5",
     "serve-static": "1.13.1",
-    "skipper": "^0.9.0-0",
+    "skipper": "^0.9.4",
     "sort-route-addresses": "^0.0.4",
     "uid-safe": "2.1.5",
     "vary": "1.1.2",


### PR DESCRIPTION
Changes:
Bumped versions of packages:
- Skipper: `^2.0.0` » `^2.0.5`
- captains-log: `^0.9.0-0` » `^9.0.4`