### PR TITLE
Deps: bump `ejs` 3.1.7 » 3.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cookie-parser": "1.4.4",
     "cookie-signature": "1.1.0",
     "csurf": "1.10.0",
-    "ejs": "3.1.7",
+    "ejs": "3.1.10",
     "express": "4.19.2",
     "express-session": "1.17.0",
     "flaverr": "^1.10.0",


### PR DESCRIPTION
Changes:
- upgraded the `ejs` dependency to 3.1.10