### PR TITLE
Bump path-to-regexp to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "minimist": "1.2.6",
     "parley": "^3.3.4",
     "parseurl": "1.3.2",
-    "path-to-regexp": "1.5.3",
+    "path-to-regexp": "1.9.0",
     "pluralize": "1.2.1",
     "prompt": "1.2.1",
     "rc": "1.2.8",


### PR DESCRIPTION
Addresses CVE-2024-45296